### PR TITLE
Fix cephadm_bootstrap undefined error

### DIFF
--- a/roles/cephadm/tasks/prechecks.yml
+++ b/roles/cephadm/tasks/prechecks.yml
@@ -4,5 +4,4 @@
 
 - name: Set cephadm_bootstrap
   set_fact:
-    cephadm_bootstrap: True
-  when: ansible_facts.services['ceph.target'] is not defined
+    cephadm_bootstrap: "{{ ansible_facts.services['ceph.target'] is not defined }}"


### PR DESCRIPTION
The cephadm_bootstrap fact is set conditionally, but referenced
unconditionally, which may lead to an undefined variable error.

This change always sets the fact.