### PR TITLE
cephadm: Refactor bootstrap.yml

### DIFF
--- a/roles/cephadm/tasks/bootstrap.yml
+++ b/roles/cephadm/tasks/bootstrap.yml
@@ -28,48 +28,5 @@
     become: true
     when: not cephadm_check_ceph_conf.stat.exists
 
-  - name: Set public network
-    command:
-      cmd: "cephadm shell -- ceph config set global public_network {{ cephadm_public_network }}"
-    become: true
-
-  - name: Set cluster network
-    command:
-      cmd: "cephadm shell -- ceph config set global cluster_network {{ cephadm_cluster_network }}"
-    when: cephadm_cluster_network | length > 0
-    become: true
-
-  - name: Get cluster fsid
-    command:
-      cmd: "cephadm shell -- ceph fsid"
-    when: cephadm_fsid | length == 0
-    become: true
-    register: cephadm_fsid_current
-
-  - name: Template out cluster.yml
-    vars:
-      fsid: "{{ cephadm_fsid if cephadm_fsid | length > 0 else cephadm_fsid_current.stdout }}"
-    template:
-      src: "templates/cluster.yml.j2"
-      dest: "/var/run/ceph/{{ fsid }}/cephadm_cluster.yml"
-      owner: root
-      group: root
-      mode: 0644
-    become: true
-    run_once: True
-
-  - name: Apply spec
-    command:
-      cmd: >
-           cephadm shell --
-           ceph orch apply -i /var/run/ceph/cephadm_cluster.yml
-    become: true
-
-  - name: Install ceph cli on mon hosts
-    command:
-      cmd: "cephadm install ceph"
-    become: true
-    when: cephadm_install_ceph_cli
-
   delegate_to: "{{ groups['mons'][0] }}"
   run_once: True

--- a/roles/cephadm/tasks/cluster.yml
+++ b/roles/cephadm/tasks/cluster.yml
@@ -1,0 +1,38 @@
+---
+- name: Deploy Ceph cluster
+  block:
+  - name: Get cluster fsid
+    command:
+      cmd: "cephadm shell -- ceph fsid"
+    when: cephadm_fsid | length == 0
+    changed_when: false
+    become: true
+    register: cephadm_fsid_current
+
+  - name: Template out cluster.yml
+    vars:
+      fsid: "{{ cephadm_fsid if cephadm_fsid | length > 0 else cephadm_fsid_current.stdout }}"
+    template:
+      src: "templates/cluster.yml.j2"
+      dest: "/var/run/ceph/{{ fsid }}/cephadm_cluster.yml"
+      owner: root
+      group: root
+      mode: 0644
+    become: true
+    run_once: True
+
+  - name: Apply spec
+    command:
+      cmd: >
+           cephadm shell --
+           ceph orch apply -i /var/run/ceph/cephadm_cluster.yml
+    become: true
+
+  - name: Install ceph cli on mon hosts
+    command:
+      cmd: "cephadm install ceph"
+    become: true
+    when: cephadm_install_ceph_cli
+
+  delegate_to: "{{ groups['mons'][0] }}"
+  run_once: True

--- a/roles/cephadm/tasks/config.yml
+++ b/roles/cephadm/tasks/config.yml
@@ -1,0 +1,16 @@
+---
+- name: Configure Ceph
+  block:
+  - name: Set public network
+    command:
+      cmd: "cephadm shell -- ceph config set global public_network {{ cephadm_public_network }}"
+    become: true
+
+  - name: Set cluster network
+    command:
+      cmd: "cephadm shell -- ceph config set global cluster_network {{ cephadm_cluster_network }}"
+    when: cephadm_cluster_network | length > 0
+    become: true
+
+  delegate_to: "{{ groups['mons'][0] }}"
+  run_once: True

--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -5,11 +5,15 @@
 - include_tasks: "prechecks.yml"
   when: not cephadm_skip_prechecks | bool
 
-- include_tasks: "pkg_{{ ansible_os_family | lower }}.yml"
+- import_tasks: "pkg_{{ ansible_os_family | lower }}.yml"
 
-- include_tasks: "prereqs.yml"
+- import_tasks: "prereqs.yml"
 
 - include_tasks: "bootstrap.yml"
   when: cephadm_bootstrap | bool
 
-- include_tasks: "osds.yml"
+- import_tasks: "config.yml"
+
+- import_tasks: "cluster.yml"
+
+- import_tasks: "osds.yml"

--- a/roles/cephadm/tasks/osds.yml
+++ b/roles/cephadm/tasks/osds.yml
@@ -8,32 +8,33 @@
     when: cephadm_osd_devices | length > 0
     with_items: "{{ cephadm_osd_devices }}"
 
-  - name: Get cluster fsid
-    command:
-      cmd: "cephadm shell -- ceph fsid"
-    when: cephadm_fsid | length == 0
-    become: true
-    register: cephadm_fsid_current
+  - block:
+    - name: Get cluster fsid
+      command:
+        cmd: "cephadm shell -- ceph fsid"
+      when: cephadm_fsid | length == 0
+      changed_when: false
+      become: true
+      register: cephadm_fsid_current
 
-  - name: Template out osd_spec.yml
-    vars:
-      fsid: "{{ cephadm_fsid if cephadm_fsid | length > 0 else cephadm_fsid_current.stdout }}"
-    copy:
-      content: "{{ cephadm_osd_spec | to_nice_yaml(indent=2) }}"
-      dest: "/var/run/ceph/{{ fsid }}/osd_spec.yml"
-      owner: root
-      group: root
-      mode: 0644
-    when: cephadm_osd_spec | length > 0
-    become: true
+    - name: Template out osd_spec.yml
+      vars:
+        fsid: "{{ cephadm_fsid if cephadm_fsid | length > 0 else cephadm_fsid_current.stdout }}"
+      copy:
+        content: "{{ cephadm_osd_spec | to_nice_yaml(indent=2) }}"
+        dest: "/var/run/ceph/{{ fsid }}/osd_spec.yml"
+        owner: root
+        group: root
+        mode: 0644
+      become: true
 
-  - name: Apply OSDs spec
-    command:
-      cmd: >
-           cephadm shell --
-           ceph orch apply osd -i /var/run/ceph/osd_spec.yml
+    - name: Apply OSDs spec
+      command:
+        cmd: >
+             cephadm shell --
+             ceph orch apply osd -i /var/run/ceph/osd_spec.yml
+      become: true
     when: cephadm_osd_spec | length > 0
-    become: true
 
   delegate_to: "{{ groups['mons'][0] }}"
   run_once: True


### PR DESCRIPTION
Some tasks in bootstrap.yml go beyond the initial bootstrap, and may be
required if configuration changes or new hosts are added.

This change separates out configuration tasks into config.yml, and
cluster specification tasks into cluster.yml.