### PR TITLE
Fix cluster.yml when rgw is not deployed

### DIFF
--- a/roles/cephadm/templates/cluster.yml.j2
+++ b/roles/cephadm/templates/cluster.yml.j2
@@ -28,9 +28,9 @@ placement:
 service_type: crash
 placement:
   host_pattern: "*"
----
 {% if groups['rgws'] | length > 0 %}
 {% for service in cephadm_radosgw_services %}
+---
 service_type: rgw
 service_id: {{ service.id }}
 placement:


### PR DESCRIPTION
The YAML doc separator should only be included if a service is to be added.