### PR TITLE
Add required collection metadata

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: ">=2.9"


### PR DESCRIPTION
It is now required to inlude file `meta/runtime.yml` in the collection structure to avoid errors like:
```
Publishing collection artifact '/github/workspace/stackhpc-cephadm-1.3.0.tar.gz' to default https://galaxy.ansible.com/api/
Collection has been published to the Galaxy server default https://galaxy.ansible.com/api/
Waiting until Galaxy import task https://galaxy.ansible.com/api/v2/collection-imports/12172/ has completed
ERROR! Galaxy import process failed: 'requires_ansible' in meta/runtime.yml is mandatory, but no meta/runtime.yml found (Code: None)
Error: The process '/usr/local/bin/ansible-galaxy' failed with exit code 1
```