### PR TITLE
Add addr: to cluster template

### DIFF
--- a/roles/cephadm/README.md
+++ b/roles/cephadm/README.md
@@ -72,5 +72,6 @@ All Ceph hosts must be in the `ceph` group.
     * `cephadm_public_interface`: Public interface (mandatory)
     * `cephadm_public_network`: Public network including CIDR (mandatory)
   * Optional
+    * `cephadm_admin_interface`: Admin interface (default: use ``cephadm_public_interface``)
     * `cephadm_cluster_interface`: Cluster interface (optional - if not defined ceph will not use dedicated cluster network)
     * `cephadm_cluster_network`: Cluster network including CIDR (optional - if not defined ceph will not use dedicated cluster network)

--- a/roles/cephadm/defaults/main.yml
+++ b/roles/cephadm/defaults/main.yml
@@ -21,6 +21,7 @@ cephadm_ssh_public_key: "/etc/ceph/cephadm.pub"
 cephadm_ssh_private_key: "/etc/ceph/cephadm.id"
 cephadm_ssh_user: "{{ ansible_user }}"
 # Networking
+cephadm_admin_interface: "{{ cephadm_public_interface }}"
 cephadm_public_interface: ""
 cephadm_cluster_interface: ""
 cephadm_public_network: ""

--- a/roles/cephadm/templates/cluster.yml.j2
+++ b/roles/cephadm/templates/cluster.yml.j2
@@ -2,6 +2,7 @@
 ---
 service_type: host
 hostname: {{ hostvars[host]['ansible_hostname'] }}
+addr: {{ hostvars[host]['ansible_'~cephadm_admin_interface]['ipv4']['address'] }}
 labels:
 {% if host in groups['mons'] %}
 - _admin


### PR DESCRIPTION
This will define IP addresses for nodes in cluster template
and no longer rely on DNS or /etc/hosts entries.