### PR TITLE
Make rgws group really optional

### DIFF
--- a/roles/cephadm/templates/cluster.yml.j2
+++ b/roles/cephadm/templates/cluster.yml.j2
@@ -14,7 +14,7 @@ labels:
 {% if host in groups['osds'] %}
 - osd
 {% endif %}
-{% if host in groups['rgws'] %}
+{% if host in groups.get('rgws', []) %}
 - rgw
 {% endif %}
 {% endfor %}
@@ -32,7 +32,7 @@ placement:
 service_type: crash
 placement:
   host_pattern: "*"
-{% if groups['rgws'] | length > 0 %}
+{% if groups.get('rgws', []) | length > 0 %}
 {% for service in cephadm_radosgw_services %}
 ---
 service_type: rgw


### PR DESCRIPTION
Currently templating fails when group is missing.