### PR TITLE
Improve bootstrap check

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "stackhpc"
 name: "cephadm"
-version: "1.5.0"
+version: "1.5.1"
 readme: "README.md"
 authors:
   - "Michal Nasiadka"

--- a/roles/cephadm/tasks/prechecks.yml
+++ b/roles/cephadm/tasks/prechecks.yml
@@ -4,4 +4,4 @@
 
 - name: Set cephadm_bootstrap
   set_fact:
-    cephadm_bootstrap: "{{ ansible_facts.services['ceph.target'] is not defined }}"
+    cephadm_bootstrap: "{{ ansible_facts.services | dict2items | selectattr('key', 'match', '^ceph.*') | list | length == 0 }}"


### PR DESCRIPTION
Unfortunately sometimes service_facts does not list ceph.target,
although it's there.

Let's check for ^ceph.* in systemd unit names