### PR TITLE
add logrotate package to prerequisites

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "stackhpc"
 name: "cephadm"
-version: "1.6.0"
+version: "1.6.1"
 readme: "README.md"
 authors:
   - "Michal Nasiadka"

--- a/roles/cephadm/tasks/prereqs.yml
+++ b/roles/cephadm/tasks/prereqs.yml
@@ -56,3 +56,9 @@
     state: present
     key: "{{ content }}"
   become: true
+
+- name: Ensure the Logrotate package is installed
+  package:
+    name: logrotate
+    state: present
+  become: True


### PR DESCRIPTION
centos-minimal and ubuntu-minimal builds doesn't have logrotate installed by default, therefore ceph logs can fill filesystem. 
Adding logrotate package as a prerequisite. APT/DNF cache got updated in previous task when installing cephadm package