### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/roles/cephadm/tasks/bootstrap.yml
+++ b/roles/cephadm/tasks/bootstrap.yml
@@ -3,7 +3,7 @@
   block:
   - name: Bootstrap cephadm
     vars:
-      mon_ip: "{{ hostvars[inventory_hostname]['ansible_'~cephadm_public_interface].ipv4.address }}"
+      mon_ip: "{{ hostvars[inventory_hostname].ansible_facts[cephadm_public_interface].ipv4.address }}"
       monitoring_stack: "{{ '--skip-monitoring-stack' if not (cephadm_enable_monitoring | bool) else '' }}"
       dashboard: "{{ '--skip-dashboard' if not cephadm_enable_dashboard | bool else '' }}"
       firewalld: "{{ '--skip-firewalld' if not cephadm_enable_firewalld | bool else '' }}"

--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -5,7 +5,7 @@
 - include_tasks: "prechecks.yml"
   when: not cephadm_skip_prechecks | bool
 
-- include_tasks: "pkg_{{ ansible_os_family | lower }}.yml"
+- include_tasks: "pkg_{{ ansible_facts.os_family | lower }}.yml"
 
 - include_tasks: "prereqs.yml"
 

--- a/roles/cephadm/tasks/osds.yml
+++ b/roles/cephadm/tasks/osds.yml
@@ -3,7 +3,7 @@
   block:
   - name: Add OSDs individually
     command:
-      cmd: "cephadm daemon add osd {{ ansible_hostname }}:{{ item }}"
+      cmd: "cephadm daemon add osd {{ ansible_facts.hostname }}:{{ item }}"
     become: true
     when: cephadm_osd_devices | length > 0
     with_items: "{{ cephadm_osd_devices }}"

--- a/roles/cephadm/tasks/pkg_debian.yml
+++ b/roles/cephadm/tasks/pkg_debian.yml
@@ -7,7 +7,7 @@
 
 - name: Ensure Ceph repositories are defined
   apt_repository:
-    repo: "deb https://download.ceph.com/debian-{{ item }}/ {{ ansible_distribution_release }} main"
+    repo: "deb https://download.ceph.com/debian-{{ item }}/ {{ ansible_facts.distribution_release }} main"
     state: "{{ 'present' if item == cephadm_ceph_release else 'absent' }}"
   when: not cephadm_custom_repos | bool
   become: true

--- a/roles/cephadm/templates/cluster.yml.j2
+++ b/roles/cephadm/templates/cluster.yml.j2
@@ -1,8 +1,8 @@
 {% for host in groups['ceph'] %}
 ---
 service_type: host
-hostname: {{ hostvars[host]['ansible_hostname'] }}
-addr: {{ hostvars[host]['ansible_'~cephadm_admin_interface]['ipv4']['address'] }}
+hostname: {{ hostvars[host].ansible_facts.hostname }}
+addr: {{ hostvars[host].ansible_facts[cephadm_admin_interface]['ipv4']['address'] }}
 labels:
 {% if host in groups['mons'] %}
 - _admin


### PR DESCRIPTION
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts.<fact>.

This change updates all references to Ansible facts from using
individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars