### PR TITLE
Stop using apt-key

### DIFF
--- a/roles/cephadm/tasks/pkg_debian.yml
+++ b/roles/cephadm/tasks/pkg_debian.yml
@@ -1,13 +1,27 @@
 ---
-- name: Add Ceph signing keys
-  apt_key:
-    keyserver: keyserver.ubuntu.com
-    id: E84AC2C0460F3994
+- name: Ensure keys directory exists
+  file:
+    path: "{{ cephadm_apt_key_path | dirname }}"
+    owner: root
+    group: root
+    mode: 0755
+    state: directory
+  when: not cephadm_custom_repos | bool
+  become: true
+
+- name: Ensure keys exist
+  get_url:
+    url: "{{ cephadm_apt_key_url }}"
+    dest: "{{ cephadm_apt_key_path }}"
+    owner: root
+    group: root
+    mode: 0644
+  when: not cephadm_custom_repos | bool
   become: true
 
 - name: Ensure Ceph repositories are defined
   apt_repository:
-    repo: "deb https://download.ceph.com/debian-{{ item }}/ {{ cephadm_apt_repo_dist }} main"
+    repo: "deb [signed-by={{ cephadm_apt_key_path }}] https://download.ceph.com/debian-{{ item }}/ {{ cephadm_apt_repo_dist }} main"
     state: "{{ 'present' if item == cephadm_ceph_release else 'absent' }}"
   when: not cephadm_custom_repos | bool
   become: true

--- a/roles/cephadm/tasks/pkg_debian.yml
+++ b/roles/cephadm/tasks/pkg_debian.yml
@@ -1,4 +1,11 @@
 ---
+# Remove any old Ceph keys added to the main keyring.
+- name: Clean up old key
+  apt_key:
+    id: E84AC2C0460F3994
+    state: absent
+  become: true
+
 - name: Ensure keys directory exists
   file:
     path: "{{ cephadm_apt_key_path | dirname }}"

--- a/roles/cephadm/vars/main.yml
+++ b/roles/cephadm/vars/main.yml
@@ -5,3 +5,5 @@ cephadm_rpm_repos:
 cephadm_ceph_releases:
   - "octopus"
   - "pacific"
+cephadm_apt_key_url: "https://download.ceph.com/keys/release.asc"
+cephadm_apt_key_path: "/usr/local/share/keyrings/ceph.asc"


### PR DESCRIPTION
1. it is deprecated
2. it does not currently work with a proxy, and I could not get it to
   work by adding --keyserver-options http-proxy=<proxy>

Instead of apt-key, we use a more secure approach of downloading the key
to a directory, and marking the repository as being signed-by that key.
The get_url module will automatically use any proxy configuration in the
environment.
