### PR TITLE
cephadm: Log in to Docker registry when a username is provided

### DIFF
--- a/roles/cephadm/tasks/prereqs.yml
+++ b/roles/cephadm/tasks/prereqs.yml
@@ -63,3 +63,11 @@
     name: logrotate
     state: present
   become: True
+
+- name: Log into Docker registry
+  docker_login:
+    registry: "{{ cephadm_registry_url }}"
+    username: "{{ cephadm_registry_username }}"
+    password: "{{ cephadm_registry_password }}"
+  when: cephadm_registry_username | length > 0
+  become: true


### PR DESCRIPTION
Without this, the cluster may fail to deploy because it can't pull images.
