### PR TITLE
Fix individual OSD creation

### DIFF
--- a/roles/cephadm/tasks/osds.yml
+++ b/roles/cephadm/tasks/osds.yml
@@ -3,7 +3,9 @@
   block:
   - name: Add OSDs individually
     command:
-      cmd: "cephadm daemon add osd {{ ansible_facts.hostname }}:{{ item }}"
+      cmd: >
+           cephadm shell --
+           ceph orch daemon add osd {{ ansible_facts.hostname }}:{{ item }}
     become: true
     when: cephadm_osd_devices | length > 0
     with_items: "{{ cephadm_osd_devices }}"

--- a/roles/cephadm/tasks/osds.yml
+++ b/roles/cephadm/tasks/osds.yml
@@ -7,7 +7,7 @@
          ceph orch daemon add osd {{ ansible_facts.hostname }}:{{ item }}
   become: true
   register: osd_add_result
-  changed_when: osd_add_result.stdout != "Created no osd(s) on host " + ansible_facts.hostname  + "; already created?"
+  changed_when: not osd_add_result.stdout.startswith("Created no osd(s) on host")
   delegate_to: "{{ omit if 'mons' in group_names else groups['mons'][0] }}"
   when: cephadm_osd_devices | length > 0
   with_items: "{{ cephadm_osd_devices }}"

--- a/roles/cephadm/tasks/osds.yml
+++ b/roles/cephadm/tasks/osds.yml
@@ -1,21 +1,26 @@
 ---
+
+- name: Add OSDs individually
+  command:
+    cmd: >
+         cephadm shell --
+         ceph orch daemon add osd {{ ansible_facts.hostname }}:{{ item }}
+  become: true
+  register: osd_add_result
+  changed_when: osd_add_result.stdout != "Created no osd(s) on host " + ansible_facts.hostname  + "; already created?"
+  delegate_to: "{{ omit if 'mons' in group_names else groups['mons'][0] }}"
+  when: cephadm_osd_devices | length > 0
+  with_items: "{{ cephadm_osd_devices }}"
+
 - name: Add OSDs
   block:
-  - name: Add OSDs individually
-    command:
-      cmd: >
-           cephadm shell --
-           ceph orch daemon add osd {{ ansible_facts.hostname }}:{{ item }}
-    become: true
-    when: cephadm_osd_devices | length > 0
-    with_items: "{{ cephadm_osd_devices }}"
-
   - name: Get cluster fsid
     command:
       cmd: "cephadm shell -- ceph fsid"
     when: cephadm_fsid | length == 0
     become: true
     register: cephadm_fsid_current
+    changed_when: false
 
   - name: Template out osd_spec.yml
     vars:


### PR DESCRIPTION
This fixes a couple of problems.

- task was using `cephadm daemon add ...` rather than `cephadm shell -- ceph orch daemon add ...`
- task was part of the `run_once` block, but it needs to run once per host.