### PR TITLE
Debian template fix and repository workaround

### DIFF
--- a/roles/cephadm/tasks/pkg_debian.yml
+++ b/roles/cephadm/tasks/pkg_debian.yml
@@ -30,7 +30,9 @@
   apt_repository:
     repo: "deb [signed-by={{ cephadm_apt_key_path }}] https://download.ceph.com/debian-{{ item }}/ {{ cephadm_apt_repo_dist }} main"
     state: "{{ 'present' if item == cephadm_ceph_release else 'absent' }}"
-  when: not cephadm_custom_repos | bool
+# there are not yet official repos for Ubuntu 22.04 so we use canonical repo
+# see https://docs.ceph.com/en/latest/cephadm/install/#cephadm-install-distros
+  when: not cephadm_custom_repos | bool and item != "quincy"
   become: true
   loop: "{{ cephadm_ceph_releases }}"
 

--- a/roles/cephadm/templates/cluster.yml.j2
+++ b/roles/cephadm/templates/cluster.yml.j2
@@ -54,6 +54,7 @@ spec:
   {{ service.spec | to_nice_yaml }}
 {% endif %}
 {% endfor %}
+{% endif %}
 {% if groups.get('ingress', []) | length > 0 %}
 {% for service in cephadm_ingress_services %}
 ---


### PR DESCRIPTION
There is missing closing `endif `tag on the template for ceph cluster config.
Added conditional to handle non-existing ceph quincy repository (use canonical one instead as suggested
by official Ceph documentation)
See also https://stackoverflow.com/questions/74046155/cephadm-error-add-repo-does-not-have-a-release-file