### PR TITLE
Fix bootstrap failure with some registry passwords

### DIFF
--- a/roles/cephadm/tasks/bootstrap.yml
+++ b/roles/cephadm/tasks/bootstrap.yml
@@ -21,9 +21,9 @@
          --ssh-user "{{ cephadm_ssh_user }}"
          {% endif %}
          {% if cephadm_registry_url | length > 0 %}
-         --registry-url={{ cephadm_registry_url }}
-         --registry-username={{ cephadm_registry_username }}
-         --registry-password={{ cephadm_registry_password }}
+         --registry-url "{{ cephadm_registry_url }}"
+         --registry-username "{{ cephadm_registry_username }}"
+         --registry-password "{{ cephadm_registry_password }}"
          {% endif %}
          --skip-pull
          {% if cephadm_fsid | length > 0 %}


### PR DESCRIPTION
This is necessary to avoid a failure if the password contains whitespace characters. If the password was set to "foo bar baz", the role would fail with:

    cephadm: error: unrecognized arguments: bar baz

Quotes are applied to the other registry arguments for consistency.