### PR TITLE
Fix deployment with FQDN hostnames

### DIFF
--- a/roles/cephadm/tasks/osds.yml
+++ b/roles/cephadm/tasks/osds.yml
@@ -9,7 +9,7 @@
   command:
     cmd: >
          cephadm shell --
-         ceph orch daemon add osd {{ ansible_facts.hostname }}:{{ item }}
+         ceph orch daemon add osd {{ ansible_facts.nodename }}:{{ item }}
   become: true
   register: osd_add_result
   changed_when: not osd_add_result.stdout.startswith("Created no osd(s) on host")

--- a/roles/cephadm/templates/cluster.yml.j2
+++ b/roles/cephadm/templates/cluster.yml.j2
@@ -1,7 +1,7 @@
 {% for host in groups['ceph'] %}
 ---
 service_type: host
-hostname: {{ hostvars[host].ansible_facts.hostname }}
+hostname: {{ hostvars[host].ansible_facts.nodename }}
 {% set cephadm_admin_interface = hostvars[host]['cephadm_admin_interface'] %}
 addr: {{ hostvars[host]['ansible_facts'][cephadm_admin_interface]['ipv4']['address'] }}
 labels:


### PR DESCRIPTION
cephadm demands that the name of the host given via ceph orch host add
equals the output of hostname on remote hosts [1].

In Ansible, the output of hostname is obtained with the nodename fact.
The hostname variable only returns the name until the first dot. See a
similar change in kolla-ansible for more details [2].

[1] https://docs.ceph.com/en/quincy/cephadm/host-management/#cephadm-fqdn
[2] https://review.opendev.org/c/openstack/kolla-ansible/+/660463
