### PR TITLE
Enable override of base command used in the command role

### DIFF
--- a/roles/commands/README.md
+++ b/roles/commands/README.md
@@ -19,7 +19,14 @@ with at least one host in it - see the `cephadm` role for more details.
 
 ## Role variables
 
-* `cephadm_commands`: A list of commands to pass to `cephadm shell -- ceph`
+
+* `cephadm_command`: The command to use with the list of commands to execute - defaults to `ceph`, but can be any command found in the `quay.io/ceph/ceph:<tag>` image.
+   Example:
+   ```
+          cephadm_command: radosgw-admin
+   ```
+
+* `cephadm_commands`: A list of commands to pass to `cephadm shell -- {{ cephadm_command }}`
    Example:
    ```
           cephadm_commands:

--- a/roles/commands/defaults/main.yml
+++ b/roles/commands/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
+cephadm_command: ceph
 cephadm_commands: []

--- a/roles/commands/tasks/main.yml
+++ b/roles/commands/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Execute custom commands
   command:
-    cmd: "cephadm shell -- ceph {{ item }}"
+    cmd: "cephadm shell -- {{ cephadm_command }} {{ item }}"
   register: cephadm_commands_result
   with_items: "{{ cephadm_commands }}"
   become: true


### PR DESCRIPTION
Hi - this PR enables the default command (`ceph`) to be overridden, so that other tasks can be automated such as executing `radosgw-admin` for configuration, or user setup etc.