### PR TITLE
Install cephadm without weak dependencies

### DIFF
--- a/roles/cephadm/tasks/pkg_redhat.yml
+++ b/roles/cephadm/tasks/pkg_redhat.yml
@@ -29,6 +29,7 @@
 - name: Install cephadm package
   dnf:
     name: "cephadm"
+    install_weak_deps: false
     state: "{{ 'latest' if cephadm_package_update | bool else 'present' }}"
     update_cache: true
   become: true


### PR DESCRIPTION
The latest cephadm package installs podman as a weak dependency. Disable weak dependencies and assume that Docker or Podman is already installed and configured.