### PR TITLE
Add support for Ubuntu 22.04 (Jammy)

### DIFF
--- a/roles/cephadm/tasks/pkg_debian.yml
+++ b/roles/cephadm/tasks/pkg_debian.yml
@@ -32,7 +32,7 @@
     state: "{{ 'present' if item == cephadm_ceph_release else 'absent' }}"
 # there are not yet official repos for Ubuntu 22.04 so we use canonical repo
 # see https://docs.ceph.com/en/latest/cephadm/install/#cephadm-install-distros
-  when: not cephadm_custom_repos | bool and item != "quincy"
+  when: not cephadm_custom_repos | bool and ansible_facts['distribution_release'] != 'jammy'
   become: true
   loop: "{{ cephadm_ceph_releases }}"
 


### PR DESCRIPTION
Adds support for Jammy by bypassing the official repos for cephadm and defaulting to the ubuntu packages instead. The official ceph repos have no support for any version of cephadm for Jammy. Hence the need to use the ubuntu repos for all versions of cephadm.