### PR TITLE
Add info on Ubuntu 22.04

### DIFF
--- a/roles/cephadm/README.md
+++ b/roles/cephadm/README.md
@@ -30,7 +30,7 @@ All Ceph hosts must be in the `ceph` group.
   * `cephadm_ceph_release`: Ceph release to deploy (default: pacific)
   * `cephadm_fsid`: FSID to use for cluster (default: empty - cephadm will generate FSID)
   * `cephadm_recreate`: If existing cluster should be destroyed and recreated (default: false)
-  * `cephadm_custom_repos`: If enabled - the role won't define yum/apt repositories (default: false)
+  * `cephadm_custom_repos`: If enabled - the role won't define yum/apt repositories. If using Ubuntu 22.04 this should be set to true. (default: false)
   * `cephadm_package_update`: If enabled - cephadm package will be updated to latest version (default: false)
   * `cephadm_host_labels`: If set (list format) - those additional labels will be applied to host definitions (default: [] - empty list)
   * Bootstrap settings

--- a/roles/cephadm/tasks/pkg_debian.yml
+++ b/roles/cephadm/tasks/pkg_debian.yml
@@ -30,9 +30,7 @@
   apt_repository:
     repo: "deb [signed-by={{ cephadm_apt_key_path }}] https://download.ceph.com/debian-{{ item }}/ {{ cephadm_apt_repo_dist }} main"
     state: "{{ 'present' if item == cephadm_ceph_release else 'absent' }}"
-# there are not yet official repos for Ubuntu 22.04 so we use canonical repo
-# see https://docs.ceph.com/en/latest/cephadm/install/#cephadm-install-distros
-  when: not cephadm_custom_repos | bool and item != "quincy"
+  when: not cephadm_custom_repos | bool
   become: true
   loop: "{{ cephadm_ceph_releases }}"
 


### PR DESCRIPTION
Adds information on what to do if you have Ubuntu 22.04. Also removes the code that is supposed to skip amending apt repositories in favour of using the `cephadm_custom_repos` variable.