### PR TITLE
Fix spec indentation in cluster.yml

### DIFF
--- a/roles/cephadm/templates/cluster.yml.j2
+++ b/roles/cephadm/templates/cluster.yml.j2
@@ -59,8 +59,7 @@ networks:
 {% endif %}
 {% endif %}
 {% if service.spec is defined %}
-spec:
-  {{ service.spec | to_nice_yaml }}
+{{ {"spec": service.spec} | to_nice_yaml(indent=2) }}
 {% endif %}
 {% endfor %}
 {% endif %}
@@ -72,6 +71,6 @@ service_id: {{ service.id }}
 placement:
   label: ingress
 spec:
-  {{ service.spec | to_nice_yaml }}
+{{ {"spec": service.spec} | to_nice_yaml(indent=2) }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
The spec dictionary was badly indented when templating cluster.yml, because to_nice_yaml does not take into account the initial indentation required. The result would like like this:

    spec:
      key1: value1
    key2: value2
    key3: value3

Fix by passing the whole spec key and value into to_nice_yaml. Also set indent parameter to 2 spaces to match the rest of the file.