### PR TITLE
Fix ansible-tests on 2.16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,9 +56,9 @@ jobs:
       - name: Run ansible-test units
         working-directory: ansible_collections/stackhpc/cephadm
         run: |
-          ansible-test units --verbose --docker --coverage
-          ansible-test coverage xml
-          ansible-test coverage html
+          ansible-test units --verbose --docker --coverage --requirements
+          ansible-test coverage xml --requirements
+          ansible-test coverage html --requirements
 
       - name: Print coverage report
         working-directory: ansible_collections/stackhpc/cephadm

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,6 @@
 ansible>=2.9
 ansible-lint<7
 antsibull-changelog
-coverage<=6.5.0
 mock
 pytest
 pytest-forked

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,0 +1,13 @@
+plugins/modules/cephadm_pool.py pylint:disallowed-name
+plugins/modules/cephadm_crush_rule.py validate-modules:missing-gplv3-license
+plugins/modules/cephadm_crush_rule.py validate-modules:parameter-state-invalid-choice
+plugins/modules/cephadm_crush_rule.py validate-modules:invalid-documentation
+plugins/modules/cephadm_ec_profile.py validate-modules:invalid-documentation
+plugins/modules/cephadm_ec_profile.py validate-modules:missing-gplv3-license
+plugins/modules/cephadm_key.py validate-modules:invalid-documentation
+plugins/modules/cephadm_key.py validate-modules:missing-gplv3-license
+plugins/modules/cephadm_key.py validate-modules:parameter-state-invalid-choice
+plugins/modules/cephadm_pool.py validate-modules:missing-gplv3-license
+plugins/modules/cephadm_pool.py validate-modules:parameter-state-invalid-choice
+plugins/modules/cephadm_pool.py validate-modules:invalid-documentation
+plugins/modules/cephadm_pool.py validate-modules:doc-default-does-not-match-spec


### PR DESCRIPTION
Add tests/sanity/ignore-2.16.txt (yes, in collections a file per
version is required)
Instead of installing coverage in test-requirements - adding
--requirements arg to ansible-test to install the correct version
(bypasses the need to manage exact version in test-requirements.txt
)