### PR TITLE
Add support for ceph clusters using podman

### DIFF
--- a/roles/cephadm/README.md
+++ b/roles/cephadm/README.md
@@ -28,6 +28,7 @@ All Ceph hosts must be in the `ceph` group.
 
 * General
   * `cephadm_ceph_release`: Ceph release to deploy (default: quincy)
+  * `cephadm_container_engine`: Whether to use docker_login or podman_login (default: docker)
   * `cephadm_fsid`: FSID to use for cluster (default: empty - cephadm will generate FSID)
   * `cephadm_recreate`: If existing cluster should be destroyed and recreated (default: false)
   * `cephadm_custom_repos`: If enabled - the role won't define yum/apt repositories. If using Ubuntu 22.04 this should be set to true. (default: false)

--- a/roles/cephadm/defaults/main.yml
+++ b/roles/cephadm/defaults/main.yml
@@ -44,3 +44,5 @@ cephadm_osd_spec: []
 cephadm_radosgw_services: []
 # Ingress
 cephadm_ingress_services: []
+# Container Engine
+cephadm_container_engine: "docker"

--- a/roles/cephadm/tasks/prechecks.yml
+++ b/roles/cephadm/tasks/prechecks.yml
@@ -5,3 +5,7 @@
 - name: Set cephadm_bootstrap
   set_fact:
     cephadm_bootstrap: "{{ ansible_facts.services | dict2items | selectattr('key', 'match', '^ceph.*') | list | length == 0 }}"
+
+- name: Check if specified container engine is installed
+  command: "which {{ cephadm_container_engine }}"
+  changed_when: false

--- a/roles/cephadm/tasks/prereqs.yml
+++ b/roles/cephadm/tasks/prereqs.yml
@@ -14,9 +14,21 @@
   become: true
 
 - name: Log into Docker registry
+  containers.podman.podman_login:
+    registry: "{{ cephadm_registry_url }}"
+    username: "{{ cephadm_registry_username }}"
+    password: "{{ cephadm_registry_password }}"
+  when:
+    - cephadm_registry_username | length > 0
+    - cephadm_container_engine == 'podman'
+  become: true
+
+- name: Log into Docker registry
   docker_login:
     registry: "{{ cephadm_registry_url }}"
     username: "{{ cephadm_registry_username }}"
     password: "{{ cephadm_registry_password }}"
-  when: cephadm_registry_username | length > 0
+  when:
+    - cephadm_registry_username | length > 0
+    - cephadm_container_engine == 'docker'
   become: true


### PR DESCRIPTION
Use `containers.podman.podman_login` instead of docker login when setting `cephadm_container_engine` to podman