### PR TITLE
Pull ceph images with tag after docker login

### DIFF
--- a/roles/cephadm/tasks/prereqs.yml
+++ b/roles/cephadm/tasks/prereqs.yml
@@ -32,3 +32,22 @@
     - cephadm_registry_username | length > 0
     - cephadm_container_engine == 'docker'
   become: true
+
+- name: Pull ceph image with Podman
+  containers.podman.podman_image:
+    name: "{{ cephadm_image }}"
+    state: present
+  when:
+    - cephadm_image | length > 0
+    - cephadm_container_engine == 'podman'
+  become: true
+
+- name: Pull ceph image with Docker
+  docker_image:
+    source: pull
+    name: "{{ cephadm_image }}"
+    state: present
+  when:
+    - cephadm_image | length > 0
+    - cephadm_container_engine == 'docker'
+  become: true

--- a/roles/cephadm/tasks/prereqs.yml
+++ b/roles/cephadm/tasks/prereqs.yml
@@ -43,7 +43,7 @@
   become: true
 
 - name: Pull ceph image with Docker
-  docker_image:
+  community.docker.docker_image:
     source: pull
     name: "{{ cephadm_image }}"
     state: present


### PR DESCRIPTION
Needs to merge after #142 

In some environments issues are observed with images having missing tags and this missing tag causing cephadm shell to resort to using the default image. By pulling the ceph image to a host with the correct tag cephadm shell should be able be able to detect the image and use it.

The reason for this is that when an image doesnt have a tag, running `docker images --format "{{.Digest}}"` returns nothing and in the cephadm script there is a check to see if the Digest was printed or not. If it wasn't detected then it uses the default image