### PR TITLE
fix!: use `inventory_hostname` if `ansible_host` is unset

### DIFF
--- a/roles/cephadm/tasks/osds.yml
+++ b/roles/cephadm/tasks/osds.yml
@@ -3,7 +3,7 @@
 # correctly when setting ansible_host in the next task.
 - name: Set a fact about the Ansible host
   set_fact:
-    mon_ansible_host: "{{ hostvars[inventory_hostname].ansible_host }}"
+    mon_ansible_host: "{{ hostvars[inventory_hostname].ansible_host | default(inventory_hostname) }}"
 
 - name: Add OSDs individually
   command:


### PR DESCRIPTION
If using `FQDNs` within an ansible inventory the variable `ansible_host` never gets set causing an error when setting `mon_ansible_host`.

For example the following inventory will fail with `The error was: 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'ansible_host'. 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'ansible_host'`

```
---
all:
  hosts:
    rpi-01.clstr.hodgkiss.cloud:
    rpi-02.clstr.hodgkiss.cloud:
    rpi-03.clstr.hodgkiss.cloud:

storage:
  hosts:
    rpi-01.clstr.hodgkiss.cloud:
    rpi-02.clstr.hodgkiss.cloud:
    rpi-03.clstr.hodgkiss.cloud:

ceph:
  children:
    mgrs:
    mons:
    osds:
    rgws:

mgrs:
  children:
    storage

mons:
  children:
    storage

osds:
  children:
    storage
```

One solution would be to add `ansible_host: rpi-01.clstr.hodgkiss.cloud` for each host though this would preferably be avoided. This can be done by using `default(inventory_hostname)` when setting `mon_ansible_host` if `ansible_host` is not set which only happen when using `FQDNs`.
