### PR TITLE
 Make cephadm_key module stateless

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,26 @@ stackhpc.cephadm Release Notes
 
 .. contents:: Topics
 
+v1.16.0
+=======
+
+Release Summary
+---------------
+
+Fix idempotency issue in cephadm_keys plugin. `cephadm_keys` no
+longer generates keyring files on Ceph hosts, and additional tasks
+are required to write keyring files to disk - see the cephadm_keys
+README.md for further details.
+
+
+Minor Changes
+-------------
+
+- Deprecate `generate_keys` functionality in cephadm_keys plugin
+- Deprecate `fetch_inital_keys` functionality in cephadm_keys plugin
+- Fix issue with idempotency in cephadm_keys plugin, by no longer
+  generating user keyring files on Ceph hosts.
+
 
 v1.13.0
 =======

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "stackhpc"
 name: "cephadm"
-version: "1.15.1"
+version: "1.16.0"
 readme: "README.md"
 authors:
   - "Michal Nasiadka"

--- a/plugins/modules/cephadm_key.py
+++ b/plugins/modules/cephadm_key.py
@@ -40,7 +40,7 @@ options:
         type: str
     state:
         description:
-            - If 'present' is used, the module ensures a keyring
+            - If 'present' is used, the module ensures a keyring exists
               with the associated capabilities.
               If 'absent' is used, the module will simply delete the keyring.
               If 'list' is used, the module will list all the keys and will

--- a/plugins/modules/cephadm_key.py
+++ b/plugins/modules/cephadm_key.py
@@ -40,22 +40,15 @@ options:
         type: str
     state:
         description:
-            - If 'present' is used, the module creates a keyring
+            - If 'present' is used, the module ensures a keyring
               with the associated capabilities.
-              If 'present' is used and a secret is provided the module
-              will always add the key. Which means it will update
-              the keyring if the secret changes, the same goes for
-              the capabilities.
               If 'absent' is used, the module will simply delete the keyring.
               If 'list' is used, the module will list all the keys and will
               return a json output.
               If 'info' is used, the module will return in a json format the
               description of a given keyring.
-              If 'generate_secret' is used, the module will simply output a
-              cephx keyring.
         required: false
-        choices: ['present', 'update', 'absent', 'list', 'info',
-                  'fetch_initial_keys', 'generate_secret']
+        choices: ['present', 'absent', 'list', 'info']
         default: present
         type: str
     caps:
@@ -64,26 +57,6 @@ options:
         default: {}
         required: false
         type: dict
-    secret:
-        description:
-            - keyring's secret value
-        required: false
-        default: ''
-        type: str
-    dest:
-        description:
-            - destination directory to save key
-        required: false
-        default: "/etc/ceph/"
-        type: str
-    import_key:
-        description:
-            - Whether or not to import the created keyring into Ceph.
-              This can be useful for someone that only wants to generate
-              keyrings but not add them into Ceph.
-        required: false
-        default: True
-        type: bool
     output_format:
         description:
             - The key output format when retrieving the information of an
@@ -92,54 +65,6 @@ options:
         choices: ['json', 'plain', 'xml', 'yaml']
         default: json
         type: str
-    attributes:
-        aliases:
-            - attr
-        description:
-            - File attributes
-        required: false
-        type: str
-    group:
-        description:
-            - Group name for file ownership
-        required: false
-        type: str
-    mode:
-        description:
-            - File permission mode
-        required: false
-        type: raw
-    owner:
-        description:
-            - File owner
-        required: false
-        type: str
-    selevel:
-        description:
-            - SELinux level
-        required: false
-        type: str
-    serole:
-        description:
-            - SELinux role
-        required: false
-        type: str
-    setype:
-        description:
-            - SELinux type
-        required: false
-        type: str
-    seuser:
-        description:
-            - SELinux user
-        required: false
-        type: str
-    unsafe_writes:
-        description:
-            - Enable unsafe writes
-        required: false
-        default: false
-        type: bool
 '''
 
 EXAMPLES = '''
@@ -148,14 +73,6 @@ EXAMPLES = '''
     name: "{{ item.name }}"
     state: present
     caps: "{{ item.caps }}"
-  with_items: "{{ keys_to_create }}"
-
-- name: create cephx key but don't import it in Ceph
-  ceph_key:
-    name: "{{ item.name }}"
-    state: present
-    caps: "{{ item.caps }}"
-    import_key: false
   with_items: "{{ keys_to_create }}"
 
 - name: delete cephx key
@@ -187,10 +104,6 @@ from ansible_collections.stackhpc.cephadm.plugins.module_utils.cephadm_common \
     import fatal, generate_ceph_cmd
 import datetime
 import json
-import os
-import struct
-import time
-import base64
 
 
 def str_to_bool(val):
@@ -206,19 +119,7 @@ def str_to_bool(val):
         raise ValueError("Invalid input value: %s" % val)
 
 
-def generate_secret():
-    '''
-    Generate a CephX secret
-    '''
-
-    key = os.urandom(16)
-    header = struct.pack('<hiih', 1, int(time.time()), 0, len(key))
-    secret = base64.b64encode(header + key)
-
-    return secret
-
-
-def generate_caps(_type, caps):
+def generate_caps(caps):
     '''
     Generate CephX capabilities list
     '''
@@ -226,62 +127,45 @@ def generate_caps(_type, caps):
     caps_cli = []
 
     for k, v in caps.items():
-        # makes sure someone didn't pass an empty var,
-        # we don't want to add an empty cap
-        if len(k) == 0:
-            continue
-        if _type == "ceph-authtool":
-            caps_cli.extend(["--cap"])
         caps_cli.extend([k, v])
 
     return caps_cli
 
 
-def generate_ceph_authtool_cmd(name, secret, caps, dest):  # noqa: E501
+def create_key(name, caps):  # noqa: E501
     '''
-    Generate 'ceph-authtool' command line to execute
+    Create a CephX key
     '''
+    cmd = []
 
-    cmd = [
-        'cephadm',
-        '--timeout',
-        '30',
-        'shell',
-        '--',
-        'ceph-authtool',
-        '--create-keyring',
-        dest,
-        '--name',
-        name,
-        '--add-key',
-        secret,
+    args = [
+        'get-or-create',
+        name
     ]
 
-    cmd.extend(generate_caps("ceph-authtool", caps))
+    args.extend(generate_caps(caps))
+    cmd.append(generate_ceph_cmd(sub_cmd=['auth'],
+                                 args=args))
 
     return cmd
 
 
-def create_key(module, result, name, secret, caps, import_key, dest):  # noqa: E501
+def update_key(name, caps):
     '''
-    Create a CephX key
+    Update the caps of a CephX key
     '''
 
-    cmd_list = []
-    if not secret:
-        secret = generate_secret()
+    cmd = []
 
-    cmd_list.append(generate_ceph_authtool_cmd(
-        name, secret, caps, dest))
+    args = [
+        'caps',
+        name,
+    ]
+    args.extend(generate_caps(caps))
+    cmd.append(generate_ceph_cmd(sub_cmd=['auth'],
+                                 args=args))
 
-    if import_key:
-        args = ['get-or-create', name]
-        args.extend(generate_caps(None, caps))
-        args.extend(['-o', dest])
-        cmd_list.append(generate_ceph_cmd(sub_cmd=['auth'],
-                                          args=args))
-
-    return cmd_list
+    return cmd
 
 
 def delete_key(name):
@@ -307,7 +191,7 @@ def get_key(name, dest):
     Get a CephX key (write on the filesystem)
     '''
 
-    cmd_list = []
+    cmd = []
 
     args = [
         'get',
@@ -316,10 +200,10 @@ def get_key(name, dest):
         dest,
     ]
 
-    cmd_list.append(generate_ceph_cmd(sub_cmd=['auth'],
-                                      args=args))
+    cmd.append(generate_ceph_cmd(sub_cmd=['auth'],
+                                 args=args))
 
-    return cmd_list
+    return cmd
 
 
 def info_key(name, output_format):
@@ -347,7 +231,7 @@ def list_keys():
     List all CephX keys
     '''
 
-    cmd_list = []
+    cmd = []
 
     args = [
         'ls',
@@ -355,10 +239,10 @@ def list_keys():
         'json',
     ]
 
-    cmd_list.append(generate_ceph_cmd(sub_cmd=['auth'],
-                                      args=args))
+    cmd.append(generate_ceph_cmd(sub_cmd=['auth'],
+                                 args=args))
 
-    return cmd_list
+    return cmd
 
 
 def exec_commands(module, cmd_list):
@@ -377,30 +261,21 @@ def exec_commands(module, cmd_list):
 def run_module():
     module_args = dict(
         name=dict(type='str', required=False),
-        state=dict(type='str', required=False, default='present', choices=['present', 'update', 'absent',  # noqa: E501
-                                                                           'list', 'info', 'fetch_initial_keys', 'generate_secret']),  # noqa: E501
+        state=dict(type='str', required=False, default='present', choices=['present', 'absent',  # noqa: E501
+                                                                           'list', 'info']),  # noqa: E501
         caps=dict(type='dict', required=False, default={}),
-        secret=dict(type='str', required=False, default='', no_log=True),
-        import_key=dict(type='bool', required=False, default=True),
-        dest=dict(type='str', required=False, default='/etc/ceph/'),
         output_format=dict(type='str', required=False, default='json', choices=['json', 'plain', 'xml', 'yaml'])  # noqa: E501
     )
 
     module = AnsibleModule(
         argument_spec=module_args,
-        supports_check_mode=True,
-        add_file_common_args=True,
+        supports_check_mode=True
     )
-
-    file_args = module.load_file_common_arguments(module.params)
 
     # Gather module parameters in variables
     state = module.params['state']
     name = module.params.get('name')
     caps = module.params.get('caps')
-    secret = module.params.get('secret')
-    import_key = module.params.get('import_key')
-    dest = module.params.get('dest')
     output_format = module.params.get('output_format')
 
     changed = False
@@ -423,61 +298,37 @@ def run_module():
     # Test if the key exists, if it does we skip its creation
     # We only want to run this check when a key needs to be added
     # There is no guarantee that any cluster is running and we don't need one
-    _secret = secret
     _caps = caps
     key_exist = 1
 
-    if (state in ["present", "update"]):
-        # if dest is not a directory, the user wants to change the file's name
-        # (e,g: /etc/ceph/ceph.mgr.ceph-mon2.keyring)
-        if not os.path.isdir(dest):
-            file_path = dest
-        else:
-            keyring_filename = "ceph" + "." + name + ".keyring"
-            file_path = os.path.join(dest, keyring_filename)
-
-        file_args['path'] = file_path
-
-        if import_key:
-            _info_key = []
-            rc, cmd, out, err = exec_commands(
-                module, info_key(name, output_format))  # noqa: E501
-            key_exist = rc
-            if not caps and key_exist != 0:
-                fatal("Capabilities must be provided when state is 'present'", module)  # noqa: E501
-            if key_exist != 0 and secret is None and caps is None:
-                fatal("Keyring doesn't exist, you must provide 'secret' and 'caps'", module)  # noqa: E501
-            if key_exist == 0:
-                _info_key = json.loads(out)
-                if not secret:
-                    secret = _info_key[0]['key']
-                _secret = _info_key[0]['key']
-                if not caps:
-                    caps = _info_key[0]['caps']
-                _caps = _info_key[0]['caps']
-                if secret == _secret and caps == _caps:
-                    if not os.path.isfile(file_path):
-                        rc, cmd, out, err = exec_commands(module, get_key(name, file_path))  # noqa: E501
-                        result["rc"] = rc
-                        if rc != 0:
-                            result["stdout"] = "Couldn't fetch the key {0} at {1}.".format(name, file_path)  # noqa: E501
-                            module.exit_json(**result)
-                        result["stdout"] = "fetched the key {0} at {1}.".format(name, file_path)  # noqa: E501
-
-                    result["stdout"] = "{0} already exists and doesn't need to be updated.".format(name)  # noqa: E501
-                    result["rc"] = 0
-                    module.set_fs_attributes_if_different(file_args, False)
-                    module.exit_json(**result)
-        else:
-            if os.path.isfile(file_path) and not secret or not caps:
-                result["stdout"] = "{0} already exists in {1} you must provide secret *and* caps when import_key is {2}".format(name, dest, import_key)  # noqa: E501
+    if state == "present":
+        _info_key = []
+        rc, cmd, out, err = exec_commands(
+            module, info_key(name, output_format))  # noqa: E501
+        key_exist = rc
+        if not caps and key_exist != 0:
+            fatal("Capabilities must be provided when state is 'present'", module)  # noqa: E501
+        if key_exist == 0:
+            _info_key = json.loads(out)
+            if not caps:
+                caps = _info_key[0]['caps']
+            _caps = _info_key[0]['caps']
+            if caps == _caps:
+                result["stdout"] = "{0} already exists and doesn't need to be updated.".format(name)  # noqa: E501
                 result["rc"] = 0
                 module.exit_json(**result)
-        if (key_exist == 0 and (secret != _secret or caps != _caps)) or key_exist != 0:  # noqa: E501
-            rc, cmd, out, err = exec_commands(module, create_key(
-                module, result, name, secret, caps, import_key, file_path))  # noqa: E501
+            else:
+                rc, cmd, out, err = exec_commands(module, update_key(name, caps))  # noqa: E501
+                if rc != 0:
+                    result["stdout"] = "Couldn't update caps for {0}".format(name)
+                    result["stderr"] = err
+                    module.exit_json(**result)
+                changed = True
+
+        else:
+            rc, cmd, out, err = exec_commands(module, create_key(name, caps))  # noqa: E501
             if rc != 0:
-                result["stdout"] = "Couldn't create or update {0}".format(name)
+                result["stdout"] = "Couldn't create {0}".format(name)
                 result["stderr"] = err
                 module.exit_json(**result)
             changed = True
@@ -502,13 +353,6 @@ def run_module():
         rc, cmd, out, err = exec_commands(
             module, list_keys())
 
-    elif state == "generate_secret":
-        out = generate_secret().decode()
-        cmd = ''
-        rc = 0
-        err = ''
-        changed = True
-
     endd = datetime.datetime.now()
     delta = endd - startd
 
@@ -520,6 +364,7 @@ def run_module():
         rc=rc,
         stdout=out.rstrip("\r\n"),
         stderr=err.rstrip("\r\n"),
+        name=name,
         changed=changed,
     )
 

--- a/roles/keys/README.md
+++ b/roles/keys/README.md
@@ -19,7 +19,7 @@ This role assumes the existence of the following groups:
 
 * `cephadm_keys`: A list of keys to define
    Example:
-   ```
+   ```yaml
           cephadm_keys:
             - name: client.glance
               caps:
@@ -35,3 +35,25 @@ This role assumes the existence of the following groups:
 
 Check the `cephadm_key` module docs for supported key options.
 
+* Keyrings are never written to disk on Ceph hosts by tasks in this role. If a Cephadm keyring should
+  be written to the filesystem the following approach can be taken:
+  ```yaml
+    - name: Get Ceph keys
+      stackhpc.cephadm.cephadm_key:
+        name: client.glance
+        output_format: plain
+        state: info
+      register: cephadm_key_info
+      become: true
+
+    - name: Write Ceph keys to disk
+      vars:
+        cephadm_key: "{{ cephadm_key_info.stdout }}"
+        cephadm_user: "{{ cephadm_key_info.name }}"
+      copy:
+        # Include a trailing newline.
+        content: |
+          {{ cephadm_key }}
+        dest: "/etc/ceph/ceph.{{ cephadm_user }}.keyring"
+      become: true
+  ```


### PR DESCRIPTION
This module should never write to files because they always exist inside the cephadm container, which
is ephemeral. This change removes all file-writing functions and references to keyrings.

This fixes the following failure:

```
The full traceback is:                                                                                                                                                                                             
  File "/tmp/ansible_cephadm_key_payload_51gs4a3l/ansible_cephadm_key_payload.zip/ansible/module_utils/basic.py", line 688, in selinux_context                                                                     
    ret = selinux.lgetfilecon_raw(to_native(path, errors='surrogate_or_strict'))                                                                                                                                   
  File "/tmp/ansible_cephadm_key_payload_51gs4a3l/ansible_cephadm_key_payload.zip/ansible/module_utils/compat/selinux.py", line 95, in lgetfilecon_raw                                                             
    rc = _selinux_lib.lgetfilecon_raw(path, byref(con))                                                  
  File "/tmp/ansible_cephadm_key_payload_51gs4a3l/ansible_cephadm_key_payload.zip/ansible/module_utils/compat/selinux.py", line 23, in _check_rc                                                                   
    raise OSError(errno, os.strerror(errno))
failed: [oscephpor01] (item={'name': 'client.cinder', 'caps': {'mon': 'profile rbd', 'osd': 'profile rbd pool=volumes, profile rbd pool=vms, profile rbd-read-only pool=images', 'mgr': 'profile rbd pool=volumes, profile rbd pool=vms'}}) => changed=false                                                                
  ansible_loop_var: item                                                                                 
  invocation:                                                                                            
    module_args:                                                                                         
      attributes: null                                                                                   
      caps:                                                                                              
        mgr: profile rbd pool=volumes, profile rbd pool=vms                                              
        mon: profile rbd                                                                                 
        osd: profile rbd pool=volumes, profile rbd pool=vms, profile rbd-read-only pool=images           
      dest: /etc/ceph/                                                                                   
      group: null                                                                                        
      import_key: true                                                                                   
      mode: null                                                                                         
      name: client.cinder                                                                                                                                                                                          
      output_format: json                           
      owner: null                                                                                                                                                                                                  
      secret: ''                                    
      selevel: null                                                                                      
      serole: null                                                                                       
      setype: null                                                                                                                                                                                                 
      seuser: null                                                                                       
      state: present                                
      unsafe_writes: false                        
  item:                                                                                                  
    caps:                                                                                                
      mgr: profile rbd pool=volumes, profile rbd pool=vms                                                
      mon: profile rbd                              
      osd: profile rbd pool=volumes, profile rbd pool=vms, profile rbd-read-only pool=images             
    name: client.cinder                             
  msg: path /etc/ceph/ceph.client.cinder.keyring does not exist                                          
  path: /etc/ceph/ceph.client.cinder.keyring
  ```
  
Which is caused by [`module.set_fs_attributes_if_different` ](https://github.com/stackhpc/ansible-collection-cephadm/blob/dc767bcd1c9f67ae70ff3671d22e2c2958ff115f/plugins/modules/cephadm_key.py#L469) running on the host when the keyring file is created in a previous step in an ephemeral cephadm container, and no longer exists.

This fixes a long-standing idempotency issue, where ceph keys can be created but the module fails on subsequent invocations. A side-effect of this change: the ability to specify and generate a secret string has been removed, and users should rely on retrieving the secret key from the cluster directly by registering the output from `cephadm_key` tasks.