### PR TITLE
feat: add `Squid` ceph release

### DIFF
--- a/roles/cephadm/vars/main.yml
+++ b/roles/cephadm/vars/main.yml
@@ -7,5 +7,6 @@ cephadm_ceph_releases:
   - pacific
   - quincy
   - reef
+  - squid
 cephadm_apt_key_url: "https://download.ceph.com/keys/release.asc"
 cephadm_apt_key_path: "/usr/local/share/keyrings/ceph.asc"


### PR DESCRIPTION
Add support for `Squid` release of Ceph, however, keep `Reef` as the default.