### PR TITLE
fix: ensure hostname is short for maintenance

### DIFF
--- a/roles/enter_maintenance/defaults/main.yml
+++ b/roles/enter_maintenance/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-cephadm_hostname: "{{ ansible_facts.nodename }}"
+cephadm_hostname: "{{ ansible_facts.hostname }}"

--- a/roles/exit_maintenance/defaults/main.yml
+++ b/roles/exit_maintenance/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-cephadm_hostname: "{{ ansible_facts.nodename }}"
+cephadm_hostname: "{{ ansible_facts.hostname }}"


### PR DESCRIPTION
If entering or exiting maintenance on a host whose hostname is full qualified may lead to failure as the FQDN does not match the name used by Ceph. Therefore, we should ensure we are using the short domain name instead.