### PR TITLE
Add retry mechanism to Ceph OSD addition task

### DIFF
--- a/roles/cephadm/tasks/osds.yml
+++ b/roles/cephadm/tasks/osds.yml
@@ -20,3 +20,6 @@
     # NOTE: Without this, the delegate hosts's ansible_host variable will not
     # be respected.
     ansible_host: "{{ mon_ansible_host if 'mons' in group_names else hostvars[groups['mons'][0]].ansible_host }}"
+  until: osd_add_result.rc == 0
+  retries: 3
+  delay: 10


### PR DESCRIPTION
This change ensures the `Add OSDs individually`
task is retried up to 3 times with a 10-second delay between attempts if the Ceph orchestrator command fails (non-zero return code). This enhances task resilience by allowing transient issues to resolve before marking the operation as failed.

Resolves stackhpc/ansible-collection-cephadm#161