### PR TITLE
Add retries to cephadm package installs

### DIFF
--- a/roles/cephadm/tasks/pkg_debian.yml
+++ b/roles/cephadm/tasks/pkg_debian.yml
@@ -40,3 +40,20 @@
     state: "{{ 'latest' if cephadm_package_update | bool else 'present' }}"
     update_cache: true
   become: true
+  timeout: 600
+  ignore_errors: true
+  register: cephadm_install
+  retries: 3
+  delay: 20
+
+# NOTE(Alex-Welsh): The cephadm install task sometimes hangs indefinitely after
+# the package is installed. This is a workaround to ensure the playbook
+# completes properly.
+- name: Ensure Cephadm package has installed properly
+  apt:
+    name: "cephadm"
+    state: "{{ 'latest' if cephadm_package_update | bool else 'present' }}"
+    update_cache: true
+  become: true
+  timeout: 60
+  when: cephadm_install is failed

--- a/roles/cephadm/tasks/pkg_redhat.yml
+++ b/roles/cephadm/tasks/pkg_redhat.yml
@@ -33,3 +33,22 @@
     state: "{{ 'latest' if cephadm_package_update | bool else 'present' }}"
     update_cache: true
   become: true
+  timeout: 600
+  ignore_errors: true
+  register: cephadm_install
+  retries: 3
+  delay: 20
+
+
+# NOTE(Alex-Welsh): The cephadm install task sometimes hangs indefinitely after
+# the package is installed. This is a workaround to ensure the playbook
+# completes properly.
+- name: Ensure Cephadm package has installed properly
+  dnf:
+    name: "cephadm"
+    install_weak_deps: false
+    state: "{{ 'latest' if cephadm_package_update | bool else 'present' }}"
+    update_cache: true
+  become: true
+  timeout: 60
+  when: cephadm_install is failed


### PR DESCRIPTION
This task seems to fail a lot during multinode automated deployments. Adding retries to help it along. Currently testing: https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/12481486518