### PR TITLE
Add support for key in CephX keyring definition

### DIFF
--- a/plugins/module_utils/cephadm_common.py
+++ b/plugins/module_utils/cephadm_common.py
@@ -20,20 +20,31 @@ __metaclass__ = type
 import datetime
 
 
-def generate_ceph_cmd(sub_cmd, args):
+def generate_ceph_cmd(sub_cmd, args, key_entry=None):
     '''
     Generate 'ceph' command line to execute
     '''
+    cmd = []
 
-    cmd = [
-        'cephadm',
-        '--timeout',
-        '60',
-        'shell',
-        '--',
-        'ceph',
-    ]
-    cmd.extend(sub_cmd + args)
+    if key_entry:
+        cmd = [
+            'cephadm',
+            'shell',
+            '--',
+            'bash',
+            '-c',
+            f'echo -e "{key_entry}" | ceph {" ".join(sub_cmd)} {" ".join(args)}'
+        ]
+    else:
+        cmd = [
+            'cephadm',
+            '--timeout',
+            '60',
+            'shell',
+            '--',
+            'ceph',
+        ]
+        cmd.extend(sub_cmd + args)
 
     return cmd
 

--- a/roles/keys/tasks/main.yml
+++ b/roles/keys/tasks/main.yml
@@ -4,7 +4,8 @@
     name: "{{ item.name }}"
     state: "{{ item.state | default(omit) }}"
     caps: "{{ item.caps }}"
-    secret: "{{ item.key | default(omit) }}"
+    key: "{{ item.key | default(omit) }}"
   with_items: "{{ cephadm_keys }}"
   delegate_to: "{{ groups['mons'][0] }}"
   run_once: true
+  no_log: "{{ item.key is defined }}"


### PR DESCRIPTION
The cephadm_key Ansible module now supports defining key for CephX keyrings, enabling more flexible key management and integration within Ceph clusters.

This feature is particularly useful with Kolla-Ansible, as it allows clear definition of keys with specific capabilities and key values. Keys can now be stored securely in Git configurations or Vault, simplifying management across both projects.

Resolves stackhpc#165