### PR TITLE
Run cephadm_pool task as sudo

### DIFF
--- a/roles/pools/tasks/main.yml
+++ b/roles/pools/tasks/main.yml
@@ -17,3 +17,4 @@
   with_items: "{{ cephadm_pools }}"
   delegate_to: "{{ groups['mons'][0] }}"
   run_once: true
+  become: true


### PR DESCRIPTION
The `cephadm_pool` Ansible module
now explicitly uses `become: true` to ensure
it is executed with elevated privileges.

This change is necessary because `cephadm`
requires sudo permissions to manage Ceph pools.

Resolves stackhpc#169