### PR TITLE
Introduce role for service specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Roles:
 * [exit_maintenance](roles/exit_maintenance/README.md) for removing hosts from maintenance
 * [keys](roles/keys/README.md) for defining auth keys
 * [pools](roles/pools/README.md) for defining pools
+* [service_spec](roles/service_spec/README.md) for arbitrary service definition
 
 ## Using this collection
 

--- a/roles/service_spec/README.md
+++ b/roles/service_spec/README.md
@@ -1,0 +1,76 @@
+# service_spec
+
+This role creates and updates arbitrary service specifications.
+It is recommended to be used only where a more specific role does not yet
+exist.
+
+## Prerequisites
+
+### Host prerequisites
+
+* The role assumes target hosts connection over SSH with user that has passwordless sudo configured.
+* Either direct Internet access or private registry with desired Ceph image accessible to all hosts is required.
+
+### Inventory
+
+This role assumes the existence of the following groups:
+
+* `mons`
+
+All Ceph hosts must be in the `ceph` group.
+
+This role is executed on `cephadm_bootstrap_host`. This defaults to the
+first member of the mon group.
+
+## Role variables
+
+* `cephadm_service_spec`: Service spec to apply in YAML (recommended) or dict
+  format.
+  Example:
+  ```
+      cephadm_service_spec: |
+        service_type: nfs
+        service_id: cephnfs
+        placement:
+          count: 1
+          hosts:
+            - host1
+            - host2
+            - host3
+        spec:
+          port: 2049
+          enable_haproxy_protocol: true
+        ---
+        service_type: container
+        service_id: foo
+        placement:
+          hosts:
+            - host1
+            - host2
+            - host3
+        spec:
+          image: docker.io/library/foo:latest
+          entrypoint: /usr/bin/foo
+          uid: 1000
+          gid: 1000
+          args:
+            - "--net=host"
+            - "--cpus=2"
+          ports:
+            - 8080
+            - 8443
+          envs:
+            - PORT=8080
+            - PUID=1000
+            - PGID=1000
+          volume_mounts:
+            CONFIG_DIR: /etc/foo
+          bind_mounts:
+            - ['type=bind', 'source=lib/modules', 'destination=/lib/modules', 'ro=true']
+          dirs:
+            - CONFIG_DIR
+          files:
+            CONFIG_DIR/foo.conf:
+              - refresh=true
+              - username=xyz
+              - "port: 1234"

--- a/roles/service_spec/defaults/main.yml
+++ b/roles/service_spec/defaults/main.yml
@@ -1,2 +1,2 @@
 cephadm_bootstrap_host: "{{ groups['mons'][0] }}"
-cephadm_service_specs: []
+cephadm_service_spec: []

--- a/roles/service_spec/defaults/main.yml
+++ b/roles/service_spec/defaults/main.yml
@@ -1,0 +1,2 @@
+cephadm_bootstrap_host: "{{ groups['mons'][0] }}"
+cephadm_service_specs: []

--- a/roles/service_spec/tasks/main.yml
+++ b/roles/service_spec/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Get cluster fsid
+  command:
+    cmd: "cephadm shell -- ceph fsid"
+  when: cephadm_fsid | length == 0
+  become: true
+  register: cephadm_fsid_current
+  changed_when: false
+
+- name: Template out service_spec.yml
+  vars:
+    fsid: "{{ cephadm_fsid if cephadm_fsid | length > 0 else cephadm_fsid_current.stdout }}"
+  copy:
+    content: "{{ cephadm_service_spec | to_nice_yaml if cephadm_service_spec is mapping else cephadm_service_spec }}"
+    dest: "/var/run/ceph/{{ fsid }}/service_spec.yml"
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+
+- name: Apply service spec
+  command:
+    cmd: >
+         cephadm shell --
+         ceph orch apply -i /var/run/ceph/service_spec.yml
+  become: true
+  changed_when: true
+  when:
+    - cephadm_service_spec | length > 0
+    - inventory_hostname == cephadm_bootstrap_host


### PR DESCRIPTION
This role provides a mechanism to write arbitrary service definitions that can be freely applied. 

Currently introducing arbitrary services can be performed by using the `cephadm_osd_spec` and defining an alternative `service_type`.
Some options are not exposed with cephadm commands.

Providing a seperate role for service definitions avoids defining services with `cephadm_osd_spec`.

Wanted feedback if this approach is valid.

Note - There can be issues when defining both an arbitrary service and accompanying ingress service. The ingress service is defined before the backend.

If this approach is valid, then the `cephadm_ingress_services` role could be refactored to support the re-ordering of tasks.