### PR TITLE
Added workflow to auto-populate changelogs on galaxy version bump

### DIFF
--- a/.github/workflows/bump-changelogs.yml
+++ b/.github/workflows/bump-changelogs.yml
@@ -1,0 +1,10 @@
+name: Update changelogs on galaxy version bump
+on:
+  push:
+    paths:
+      - galaxy.yml
+    branches:
+      - antsibull_changelogs # change before merge
+jobs:
+  bump-changelogs:
+    uses: stackhpc/.github/.github/workflows/antsibull-release.yml@update_changelogs # todo: change to main once merged

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ stackhpc.cephadm Release Notes
 
 .. contents:: Topics
 
+v1.19.1
+=======
+
+Bugfixes
+--------
+
+- pools - cephadm_pool tasks now correctly run with sudo
+
 v1.16.0
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,15 +15,12 @@ longer generates keyring files on Ceph hosts, and additional tasks
 are required to write keyring files to disk - see the cephadm_keys
 README.md for further details.
 
-
 Minor Changes
 -------------
 
-- Deprecate `generate_keys` functionality in cephadm_keys plugin
 - Deprecate `fetch_inital_keys` functionality in cephadm_keys plugin
-- Fix issue with idempotency in cephadm_keys plugin, by no longer
-  generating user keyring files on Ceph hosts.
-
+- Deprecate `generate_keys` functionality in cephadm_keys plugin
+- Fix issue with idempotency in cephadm_keys plugin, by no longer generating user keyring files on Ceph hosts.
 
 v1.13.0
 =======
@@ -32,7 +29,6 @@ Release Summary
 ---------------
 
 Minor release adding support for choosing plugin in EC profiles
-
 
 Minor Changes
 -------------

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -32,4 +32,4 @@ releases:
       - pools - cephadm_pool tasks now correctly run with sudo
     fragments:
     - sudo-fix.yml
-    release_date: '2025-01-13'
+    release_date: '2025-01-08'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,9 +1,28 @@
 ancestor: null
 releases:
   1.13.0:
-    release_date: '2023-02-28'
     changes:
-      release_summary: |
-        Minor release adding support for choosing plugin in EC profiles
       minor_changes:
-        - Add support for choosing plugin in EC profiles
+      - Add support for choosing plugin in EC profiles
+      release_summary: 'Minor release adding support for choosing plugin in EC profiles
+
+        '
+    release_date: '2023-02-28'
+  1.16.0:
+    changes:
+      minor_changes:
+      - Deprecate `fetch_inital_keys` functionality in cephadm_keys plugin
+      - Deprecate `generate_keys` functionality in cephadm_keys plugin
+      - Fix issue with idempotency in cephadm_keys plugin, by no longer generating
+        user keyring files on Ceph hosts.
+      release_summary: 'Fix idempotency issue in cephadm_keys plugin. `cephadm_keys`
+        no
+
+        longer generates keyring files on Ceph hosts, and additional tasks
+
+        are required to write keyring files to disk - see the cephadm_keys
+
+        README.md for further details.
+
+        '
+    release_date: '2024-07-28'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -26,3 +26,10 @@ releases:
 
         '
     release_date: '2024-07-28'
+  1.19.1:
+    changes:
+      bugfixes:
+      - pools - cephadm_pool tasks now correctly run with sudo
+    fragments:
+    - sudo-fix.yml
+    release_date: '2025-01-13'

--- a/changelogs/fragments/sudo-fix.yml
+++ b/changelogs/fragments/sudo-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pools - cephadm_pool tasks now correctly run with sudo

--- a/changelogs/fragments/sudo-fix.yml
+++ b/changelogs/fragments/sudo-fix.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - pools - cephadm_pool tasks now correctly run with sudo

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "stackhpc"
 name: "cephadm"
-version: "1.19.1"
+version: "1.16.0"
 readme: "README.md"
 authors:
   - "Michal Nasiadka"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "stackhpc"
 name: "cephadm"
-version: "1.16.0"
+version: "1.19.1"
 readme: "README.md"
 authors:
   - "Michal Nasiadka"


### PR DESCRIPTION
See https://github.com/stackhpc/.github/pull/46

Requires `changelogs/fragments` to be maintained with changes since last release in fragment format specified here https://docs.ansible.com/ansible/latest/community/development_process.html#changelogs-how-to (maybe this needs future automation), which are consumed when the workflow runs

Also updated existing changelogs to be compatible with Antsibull