### PR TITLE
Fix groups existence precheck

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -37,4 +37,5 @@ releases:
     changes:
       bugfixes:
       - prechecks - fix groups existing assertion
+      - prechecks - change groups existence check to run once
     release_date: '2025-10-09'

--- a/roles/cephadm/tasks/prechecks.yml
+++ b/roles/cephadm/tasks/prechecks.yml
@@ -1,5 +1,6 @@
 ---
 - name: Assert that required Ansible groups exist
+  run_once: true
   ansible.builtin.assert:
     that: "'{{ item }}' in groups"
     msg: "Ansible '{{ item }}' group does not exist - please create one"


### PR DESCRIPTION
Fixes group existence assert to iterate over groups instead of group_names.