### PR TITLE
Add cluster bootstrapping demo to the README

### DIFF
--- a/roles/cephadm/README.md
+++ b/roles/cephadm/README.md
@@ -2,6 +2,8 @@
 
 This role bootstraps and configures Ceph using cephadm.
 
+[![asciicast](https://asciinema.org/a/752639.svg)](https://asciinema.org/a/752639)
+
 ## Prerequisites
 
 ### Host prerequisites


### PR DESCRIPTION
A demo recorded for Ceph Days Berlin 2025:

[![asciicast](https://asciinema.org/a/752639.svg)](https://asciinema.org/a/752639)
I considered adding it as .gif file, but it weights around 10MB so probably it's not worth it.