### PR TITLE
feat: add `--fsid` and `--config` to cephadm commands

### DIFF
--- a/plugins/module_utils/cephadm_common.py
+++ b/plugins/module_utils/cephadm_common.py
@@ -20,19 +20,31 @@ __metaclass__ = type
 import datetime
 
 
-def generate_ceph_cmd(sub_cmd, args):
+def generate_ceph_cmd(sub_cmd, args, image=None, fsid=None, hostname=None):
     '''
     Generate 'ceph' command line to execute
     '''
-
     cmd = [
         'cephadm',
         '--timeout',
         '60',
-        'shell',
-        '--',
-        'ceph',
     ]
+
+    if image:
+        cmd.extend(['--image', image])
+
+    cmd.append('shell')
+
+    if fsid:
+        cmd.extend(['--fsid', fsid])
+
+    if fsid and hostname:
+        cmd.extend([
+            '--config',
+            '/var/lib/ceph/{}/mon.{}/config'.format(fsid, hostname),
+        ])
+
+    cmd.extend(['--', 'ceph'])
     cmd.extend(sub_cmd + args)
 
     return cmd

--- a/plugins/modules/cephadm_crush_rule.py
+++ b/plugins/modules/cephadm_crush_rule.py
@@ -75,6 +75,21 @@ options:
             - The ceph erasure profile for erasure rule.
         required: false
         type: str
+    image:
+        description:
+            - Container image used to run cephadm/ceph commands.
+        required: false
+        type: str
+    fsid:
+        description:
+            - Ceph cluster FSID used to target the correct cluster.
+        required: false
+        type: str
+    hostname:
+        description:
+            - Hostname passed to cephadm to run commands on a specific host.
+        required: false
+        type: str
 '''
 
 EXAMPLES = '''
@@ -124,6 +139,9 @@ def create_rule(module, container_image=None):
     bucket_root = module.params.get('bucket_root')
     bucket_type = module.params.get('bucket_type')
     device_class = module.params.get('device_class')
+    image = module.params.get('image')
+    fsid = module.params.get('fsid')
+    hostname = module.params.get('hostname')
     profile = module.params.get('profile')
 
     if rule_type == 'replicated':
@@ -135,8 +153,9 @@ def create_rule(module, container_image=None):
         if profile:
             args.append(profile)
 
-    cmd = generate_ceph_cmd(['osd', 'crush', 'rule'],
-                            args)
+    cmd = generate_ceph_cmd(sub_cmd=['osd', 'crush', 'rule'],
+                            image=image, fsid=fsid, hostname=hostname,
+                            args=args)
 
     return cmd
 
@@ -147,11 +166,15 @@ def get_rule(module, container_image=None):
     '''
 
     name = module.params.get('name')
+    image = module.params.get('image')
+    fsid = module.params.get('fsid')
+    hostname = module.params.get('hostname')
 
     args = ['dump', name, '--format=json']
 
-    cmd = generate_ceph_cmd(['osd', 'crush', 'rule'],
-                            args)
+    cmd = generate_ceph_cmd(sub_cmd=['osd', 'crush', 'rule'],
+                            image=image, fsid=fsid, hostname=hostname,
+                            args=args)
 
     return cmd
 
@@ -162,11 +185,15 @@ def remove_rule(module, container_image=None):
     '''
 
     name = module.params.get('name')
+    image = module.params.get('image')
+    fsid = module.params.get('fsid')
+    hostname = module.params.get('hostname')
 
     args = ['rm', name]
 
-    cmd = generate_ceph_cmd(['osd', 'crush', 'rule'],
-                            args)
+    cmd = generate_ceph_cmd(sub_cmd=['osd', 'crush', 'rule'],
+                            image=image, fsid=fsid, hostname=hostname,
+                            args=args)
 
     return cmd
 
@@ -181,7 +208,10 @@ def main():
             bucket_type=dict(type='str', required=False, choices=['osd', 'host', 'chassis', 'rack', 'row', 'pdu', 'pod',  # noqa: E501
                                                                   'room', 'datacenter', 'zone', 'region', 'root']),  # noqa: E501
             device_class=dict(type='str', required=False),
-            profile=dict(type='str', required=False)
+            profile=dict(type='str', required=False),
+            image=dict(type='str', required=False),
+            fsid=dict(type='str', required=False),
+            hostname=dict(type='str', required=False)
         ),
         supports_check_mode=True,
         required_if=[

--- a/plugins/modules/cephadm_ec_profile.py
+++ b/plugins/modules/cephadm_ec_profile.py
@@ -82,6 +82,21 @@ options:
             - Set the failure domain for the CRUSH rule (e.g., 'rack', 'host', 'osd')
         required: false
         type: str
+    image:
+        description:
+            - Container image used to run cephadm/ceph commands.
+        required: false
+        type: str
+    fsid:
+        description:
+            - Ceph cluster FSID used to target the correct cluster.
+        required: false
+        type: str
+    hostname:
+        description:
+            - Hostname passed to cephadm to run commands on a specific host.
+        required: false
+        type: str
 
 author:
     - Guillaume Abrioux <gabrioux@redhat.com>
@@ -119,7 +134,7 @@ import json
 RETURN = '''#  '''
 
 
-def get_profile(module, name):
+def get_profile(module, name, image=None, fsid=None, hostname=None):
     '''
     Get existing profile
     '''
@@ -127,12 +142,13 @@ def get_profile(module, name):
     args = ['get', name, '--format=json']
 
     cmd = generate_ceph_cmd(sub_cmd=['osd', 'erasure-code-profile'],
+                            image=image, fsid=fsid, hostname=hostname,
                             args=args)
 
     return cmd
 
 
-def create_profile(module, name, k, m, stripe_unit, crush_device_class, crush_failure_domain, directory, plugin, force=False):  # noqa: E501
+def create_profile(module, name, k, m, stripe_unit, crush_device_class, crush_failure_domain, directory, plugin, image=None, fsid=None, hostname=None, force=False):  # noqa: E501
     '''
     Create a profile
     '''
@@ -152,12 +168,13 @@ def create_profile(module, name, k, m, stripe_unit, crush_device_class, crush_fa
         args.append('--force')
 
     cmd = generate_ceph_cmd(sub_cmd=['osd', 'erasure-code-profile'],
+                            image=image, fsid=fsid, hostname=hostname,
                             args=args)
 
     return cmd
 
 
-def delete_profile(module, name):
+def delete_profile(module, name, image=None, fsid=None, hostname=None,):
     '''
     Delete a profile
     '''
@@ -165,6 +182,7 @@ def delete_profile(module, name):
     args = ['rm', name]
 
     cmd = generate_ceph_cmd(sub_cmd=['osd', 'erasure-code-profile'],
+                            image=image, fsid=fsid, hostname=hostname,
                             args=args)
 
     return cmd
@@ -182,6 +200,9 @@ def run_module():
         crush_failure_domain=dict(type='str', required=False),
         directory=dict(type='str', required=False),
         plugin=dict(type='str', required=False),
+        image=dict(type='str', required=False),
+        fsid=dict(type='str', required=False),
+        hostname=dict(type='str', required=False)
     )
 
     module = AnsibleModule(
@@ -200,6 +221,9 @@ def run_module():
     crush_failure_domain = module.params.get('crush_failure_domain')
     directory = module.params.get('directory')
     plugin = module.params.get('plugin')
+    image = module.params.get('image')
+    fsid = module.params.get('fsid')
+    hostname = module.params.get('hostname')
 
     if module.check_mode:
         module.exit_json(
@@ -216,7 +240,7 @@ def run_module():
     changed = False
 
     if state == "present":
-        rc, cmd, out, err = exec_command(module, get_profile(module, name))  # noqa: E501
+        rc, cmd, out, err = exec_command(module, get_profile(module, name, image, fsid, hostname))  # noqa: E501
         if rc == 0:
             # the profile already exists, let's check whether we have to
             # update it
@@ -238,6 +262,9 @@ def run_module():
                                                                 crush_failure_domain,
                                                                 directory,
                                                                 plugin,
+                                                                image,
+                                                                fsid,
+                                                                hostname,
                                                                 force=True))  # noqa: E501
                 changed = True
         else:
@@ -250,12 +277,15 @@ def run_module():
                                                                     crush_device_class,  # noqa: E501
                                                                     crush_failure_domain,
                                                                     directory,
+                                                                    image,
+                                                                    fsid,
+                                                                    hostname,
                                                                     plugin))
             if rc == 0:
                 changed = True
 
     elif state == "absent":
-        rc, cmd, out, err = exec_command(module, delete_profile(module, name))  # noqa: E501
+        rc, cmd, out, err = exec_command(module, delete_profile(module, name, image, fsid, hostname))  # noqa: E501
         if not err:
             out = 'Profile {0} removed.'.format(name)
             changed = True

--- a/plugins/modules/cephadm_key.py
+++ b/plugins/modules/cephadm_key.py
@@ -65,6 +65,21 @@ options:
         choices: ['json', 'plain', 'xml', 'yaml']
         default: json
         type: str
+    image:
+        description:
+            - Container image used to run cephadm/ceph commands.
+        required: false
+        type: str
+    fsid:
+        description:
+            - Ceph cluster FSID used to target the correct cluster.
+        required: false
+        type: str
+    hostname:
+        description:
+            - Hostname passed to cephadm to run commands on a specific host.
+        required: false
+        type: str
 '''
 
 EXAMPLES = '''
@@ -132,7 +147,7 @@ def generate_caps(caps):
     return caps_cli
 
 
-def create_key(name, caps):  # noqa: E501
+def create_key(name, caps, image=None, fsid=None, hostname=None):  # noqa: E501
     '''
     Create a CephX key
     '''
@@ -145,12 +160,13 @@ def create_key(name, caps):  # noqa: E501
 
     args.extend(generate_caps(caps))
     cmd.append(generate_ceph_cmd(sub_cmd=['auth'],
+                                 image=image, fsid=fsid, hostname=hostname,
                                  args=args))
 
     return cmd
 
 
-def update_key(name, caps):
+def update_key(name, caps, image=None, fsid=None, hostname=None):
     '''
     Update the caps of a CephX key
     '''
@@ -163,12 +179,13 @@ def update_key(name, caps):
     ]
     args.extend(generate_caps(caps))
     cmd.append(generate_ceph_cmd(sub_cmd=['auth'],
+                                 image=image, fsid=fsid, hostname=hostname,
                                  args=args))
 
     return cmd
 
 
-def delete_key(name):
+def delete_key(name, image=None, fsid=None, hostname=None,):
     '''
     Delete a CephX key
     '''
@@ -181,12 +198,13 @@ def delete_key(name):
     ]
 
     cmd.append(generate_ceph_cmd(sub_cmd=['auth'],
+                                 image=image, fsid=fsid, hostname=hostname,
                                  args=args))
 
     return cmd
 
 
-def get_key(name, dest):
+def get_key(name, dest, image=None, fsid=None, hostname=None):
     '''
     Get a CephX key (write on the filesystem)
     '''
@@ -201,12 +219,13 @@ def get_key(name, dest):
     ]
 
     cmd.append(generate_ceph_cmd(sub_cmd=['auth'],
+                                 image=image, fsid=fsid, hostname=hostname,
                                  args=args))
 
     return cmd
 
 
-def info_key(name, output_format):
+def info_key(name, output_format, image=None, fsid=None, hostname=None):
     '''
     Get information about a CephX key
     '''
@@ -221,12 +240,13 @@ def info_key(name, output_format):
     ]
 
     cmd_list.append(generate_ceph_cmd(sub_cmd=['auth'],
+                                      image=image, fsid=fsid, hostname=hostname,
                                       args=args))
 
     return cmd_list
 
 
-def list_keys():
+def list_keys(image=None, fsid=None, hostname=None):
     '''
     List all CephX keys
     '''
@@ -240,6 +260,7 @@ def list_keys():
     ]
 
     cmd.append(generate_ceph_cmd(sub_cmd=['auth'],
+                                 image=image, fsid=fsid, hostname=hostname,
                                  args=args))
 
     return cmd
@@ -264,8 +285,10 @@ def run_module():
         state=dict(type='str', required=False, default='present', choices=['present', 'absent',  # noqa: E501
                                                                            'list', 'info']),  # noqa: E501
         caps=dict(type='dict', required=False, default={}),
-        output_format=dict(type='str', required=False, default='json', choices=['json', 'plain', 'xml', 'yaml'])  # noqa: E501
-    )
+        output_format=dict(type='str', required=False, default='json', choices=['json', 'plain', 'xml', 'yaml']),  # noqa: E501
+        image=dict(type='str', required=False),
+        fsid=dict(type='str', required=False),
+        hostname=dict(type='str', required=False))
 
     module = AnsibleModule(
         argument_spec=module_args,
@@ -277,6 +300,9 @@ def run_module():
     name = module.params.get('name')
     caps = module.params.get('caps')
     output_format = module.params.get('output_format')
+    image = module.params.get('image')
+    fsid = module.params.get('fsid')
+    hostname = module.params.get('hostname')
 
     changed = False
 
@@ -304,7 +330,7 @@ def run_module():
     if state == "present":
         _info_key = []
         rc, cmd, out, err = exec_commands(
-            module, info_key(name, output_format))  # noqa: E501
+            module, info_key(name, output_format, image=image, fsid=fsid, hostname=hostname))  # noqa: E501
         key_exist = rc
         if not caps and key_exist != 0:
             fatal("Capabilities must be provided when state is 'present'", module)  # noqa: E501
@@ -318,7 +344,7 @@ def run_module():
                 result["rc"] = 0
                 module.exit_json(**result)
             else:
-                rc, cmd, out, err = exec_commands(module, update_key(name, caps))  # noqa: E501
+                rc, cmd, out, err = exec_commands(module, update_key(name, caps, image=image, fsid=fsid, hostname=hostname))  # noqa: E501
                 if rc != 0:
                     result["msg"] = "Couldn't update caps for {0}".format(name)
                     result["stderr"] = err
@@ -326,7 +352,7 @@ def run_module():
                 changed = True
 
         else:
-            rc, cmd, out, err = exec_commands(module, create_key(name, caps))  # noqa: E501
+            rc, cmd, out, err = exec_commands(module, create_key(name, caps, image=image, fsid=fsid, hostname=hostname))  # noqa: E501
             if rc != 0:
                 result["msg"] = "Couldn't create {0}".format(name)
                 result["stderr"] = err
@@ -335,11 +361,11 @@ def run_module():
 
     elif state == "absent":
         rc, cmd, out, err = exec_commands(
-            module, info_key(name, output_format))  # noqa: E501
+            module, info_key(name, output_format, image=image, fsid=fsid, hostname=hostname))  # noqa: E501
         key_exist = rc
         if key_exist == 0:
             rc, cmd, out, err = exec_commands(
-                module, delete_key(name))  # noqa: E501
+                module, delete_key(name, image=image, fsid=fsid, hostname=hostname))  # noqa: E501
             if rc == 0:
                 changed = True
         else:
@@ -347,11 +373,11 @@ def run_module():
 
     elif state == "info":
         rc, cmd, out, err = exec_commands(
-            module, info_key(name, output_format))  # noqa: E501
+            module, info_key(name, output_format, image=image, fsid=fsid, hostname=hostname))  # noqa: E501
 
     elif state == "list":
         rc, cmd, out, err = exec_commands(
-            module, list_keys())
+            module, list_keys(image=image, fsid=fsid, hostname=hostname))
 
     endd = datetime.datetime.now()
     delta = endd - startd

--- a/plugins/modules/cephadm_pool.py
+++ b/plugins/modules/cephadm_pool.py
@@ -120,6 +120,21 @@ options:
         required: false
         default: false
         type: bool
+    image:
+        description:
+            - Container image used to run cephadm/ceph commands.
+        required: false
+        type: str
+    fsid:
+        description:
+            - Ceph cluster FSID used to target the correct cluster.
+        required: false
+        type: str
+    hostname:
+        description:
+            - Hostname passed to cephadm to run commands on a specific host.
+        required: false
+        type: str
 '''
 
 EXAMPLES = r'''
@@ -149,6 +164,7 @@ import json
 
 
 def check_pool_exist(name,
+                     image=None, fsid=None, hostname=None,
                      output_format='json'):
     '''
     Check if a given pool exists
@@ -157,12 +173,14 @@ def check_pool_exist(name,
     args = ['stats', name, '-f', output_format]
 
     cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
+                            image=image, fsid=fsid, hostname=hostname,
                             args=args)
 
     return cmd
 
 
 def get_application_pool(name,
+                         image=None, fsid=None, hostname=None,
                          output_format='json'):
     '''
     Get application type enabled on a given pool
@@ -171,13 +189,15 @@ def get_application_pool(name,
     args = ['application', 'get', name, '-f', output_format]
 
     cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
+                            image=image, fsid=fsid, hostname=hostname,
                             args=args)
 
     return cmd
 
 
 def enable_application_pool(name,
-                            application):
+                            application,
+                            image=None, fsid=None, hostname=None):
     '''
     Enable application on a given pool
     '''
@@ -185,13 +205,15 @@ def enable_application_pool(name,
     args = ['application', 'enable', name, application]
 
     cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
+                            image=image, fsid=fsid, hostname=hostname,
                             args=args)
 
     return cmd
 
 
 def disable_application_pool(name,
-                             application):
+                             application,
+                             image=None, fsid=None, hostname=None):
     '''
     Disable application on a given pool
     '''
@@ -200,12 +222,13 @@ def disable_application_pool(name,
             application, '--yes-i-really-mean-it']
 
     cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
+                            image=image, fsid=fsid, hostname=hostname,
                             args=args)
 
     return cmd
 
 
-def get_pool_ec_overwrites(name, output_format='json'):
+def get_pool_ec_overwrites(name, image=None, fsid=None, hostname=None, output_format='json'):
     '''
     Get EC overwrites on a given pool
     '''
@@ -214,12 +237,13 @@ def get_pool_ec_overwrites(name, output_format='json'):
             '-f', output_format]
 
     cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
+                            image=image, fsid=fsid, hostname=hostname,
                             args=args)
 
     return cmd
 
 
-def enable_ec_overwrites(name):
+def enable_ec_overwrites(name, image=None, fsid=None, hostname=None):
     '''
     Enable EC overwrites on a given pool
     '''
@@ -228,12 +252,13 @@ def enable_ec_overwrites(name):
             'true']
 
     cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
+                            image=image, fsid=fsid, hostname=hostname,
                             args=args)
 
     return cmd
 
 
-def disable_ec_overwrites(name):
+def disable_ec_overwrites(name, image=None, fsid=None, hostname=None):
     '''
     Disable EC overwrites on a given pool
     '''
@@ -242,6 +267,7 @@ def disable_ec_overwrites(name):
             'false']
 
     cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
+                            image=image, fsid=fsid, hostname=hostname,
                             args=args)
 
     return cmd
@@ -249,6 +275,7 @@ def disable_ec_overwrites(name):
 
 def get_pool_details(module,
                      name,
+                     image=None, fsid=None, hostname=None,
                      output_format='json'):
     '''
     Get details about a given pool
@@ -257,6 +284,7 @@ def get_pool_details(module,
     args = ['ls', 'detail', '-f', output_format]
 
     cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
+                            image=image, fsid=fsid, hostname=hostname,
                             args=args)
 
     rc, cmd, out, err = exec_command(module, cmd)
@@ -264,9 +292,15 @@ def get_pool_details(module,
     if rc == 0:
         out = [p for p in json.loads(out.strip()) if p['pool_name'] == name][0]
 
-    _rc, _cmd, application_pool, _err = exec_command(module,
-                                                     get_application_pool(name)
-                                                     )
+    _rc, _cmd, application_pool, _err = exec_command(
+        module,
+        get_application_pool(
+            name,
+            image=image,
+            fsid=fsid,
+            hostname=hostname,
+        ),
+    )
 
     # This is a trick because "target_size_ratio" isn't present at the same
     # level in the dict
@@ -322,6 +356,7 @@ def compare_pool_config(user_pool_config, running_pool_details):
 
 
 def list_pools(details,
+               image=None, fsid=None, hostname=None,
                output_format='json'):
     '''
     List existing pools
@@ -335,13 +370,15 @@ def list_pools(details,
     args.extend(['-f', output_format])
 
     cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
+                            image=image, fsid=fsid, hostname=hostname,
                             args=args)
 
     return cmd
 
 
 def create_pool(name,
-                user_pool_config):
+                user_pool_config,
+                image=None, fsid=None, hostname=None):
     '''
     Create a new pool
     '''
@@ -381,12 +418,13 @@ def create_pool(name,
                      user_pool_config['pg_autoscale_mode']['value']])
 
     cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
+                            image=image, fsid=fsid, hostname=hostname,
                             args=args)
 
     return cmd
 
 
-def remove_pool(name):
+def remove_pool(name, image=None, fsid=None, hostname=None):
     '''
     Remove a pool
     '''
@@ -394,12 +432,13 @@ def remove_pool(name):
     args = ['rm', name, name, '--yes-i-really-really-mean-it']
 
     cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
+                            image=image, fsid=fsid, hostname=hostname,
                             args=args)
 
     return cmd
 
 
-def update_pool(module, name, delta):
+def update_pool(module, name, delta, image=None, fsid=None, hostname=None,):
     '''
     Update an existing pool
     '''
@@ -414,6 +453,7 @@ def update_pool(module, name, delta):
                     delta[key]['value']]
 
             cmd = generate_ceph_cmd(sub_cmd=['osd', 'pool'],
+                                    image=image, fsid=fsid, hostname=hostname,
                                     args=args)
 
             rc, cmd, out, err = exec_command(module, cmd)
@@ -421,11 +461,11 @@ def update_pool(module, name, delta):
                 return rc, cmd, out, err
 
         else:
-            rc, cmd, out, err = exec_command(module, disable_application_pool(name, delta['application']['old_application']))  # noqa: E501
+            rc, cmd, out, err = exec_command(module, disable_application_pool(name, delta['application']['old_application']), image=image, fsid=fsid, hostname=hostname)  # noqa: E501
             if rc != 0:
                 return rc, cmd, out, err
 
-            rc, cmd, out, err = exec_command(module, enable_application_pool(name, delta['application']['new_application']))  # noqa: E501
+            rc, cmd, out, err = exec_command(module, enable_application_pool(name, delta['application']['new_application']), image=image, fsid=fsid, hostname=hostname)  # noqa: E501
             if rc != 0:
                 return rc, cmd, out, err
 
@@ -453,7 +493,10 @@ def run_module():
         rule_name=dict(type='str', required=False, default=None),
         expected_num_objects=dict(type='str', required=False, default="0"),
         application=dict(type='str', required=False, default=None),
-        allow_ec_overwrites=dict(type='bool', required=False, default=False)
+        allow_ec_overwrites=dict(type='bool', required=False, default=False),
+        image=dict(type='str', required=False),
+        fsid=dict(type='str', required=False),
+        hostname=dict(type='str', required=False)
     )
 
     module = AnsibleModule(
@@ -473,6 +516,9 @@ def run_module():
     target_size_ratio = module.params.get('target_size_ratio')
     application = module.params.get('application')
     allow_ec_overwrites = module.params.get('allow_ec_overwrites')
+    image = module.params.get('image')
+    fsid = module.params.get('fsid')
+    hostname = module.params.get('hostname')
 
     if (module.params.get('pg_autoscale_mode').lower() in
             ['true', 'on', 'yes']):
@@ -531,22 +577,22 @@ def run_module():
 
     if state == "present":
         rc, cmd, out, err = exec_command(module,
-                                         check_pool_exist(name))
+                                         check_pool_exist(name, image=image, fsid=fsid, hostname=hostname))
         if rc == 0:
             running_pool_details = get_pool_details(module,
-                                                    name)
+                                                    name, image=image, fsid=fsid, hostname=hostname)
             user_pool_config['pg_placement_num'] = {'value': str(running_pool_details[2]['pg_placement_num']), 'cli_set_opt': 'pgp_num'}  # noqa: E501
             delta = compare_pool_config(user_pool_config,
                                         running_pool_details[2])
 
             if user_pool_config['type']['value'] == 'erasure':
-                rc, cmd, ec_overwrites, err = exec_command(module, get_pool_ec_overwrites(name))  # noqa: E501
+                rc, cmd, ec_overwrites, err = exec_command(module, get_pool_ec_overwrites(name, image=image, fsid=fsid, hostname=hostname))  # noqa: E501
                 running_pool_ec_overwrites = json.loads(ec_overwrites.strip()).get('allow_ec_overwrites')  # noqa: E501
                 if running_pool_ec_overwrites != user_pool_config['allow_ec_overwrites']['value']:  # noqa: E501
                     if user_pool_config['allow_ec_overwrites']['value']:
-                        rc, cmd, out, err = exec_command(module, enable_ec_overwrites(name))  # noqa: E501
+                        rc, cmd, out, err = exec_command(module, enable_ec_overwrites(name, image=image, fsid=fsid, hostname=hostname))  # noqa: E501
                     else:
-                        rc, cmd, out, err = exec_command(module, disable_ec_overwrites(name))  # noqa: E501
+                        rc, cmd, out, err = exec_command(module, disable_ec_overwrites(name, image=image, fsid=fsid, hostname=hostname))  # noqa: E501
                     if rc == 0:
                         changed = True
 
@@ -564,7 +610,7 @@ def run_module():
                 else:
                     rc, cmd, out, err = update_pool(module,
                                                     name,
-                                                    delta)
+                                                    delta, image=image, fsid=fsid, hostname=hostname)
                     if rc == 0:
                         changed = True
 
@@ -573,33 +619,33 @@ def run_module():
         else:
             rc, cmd, out, err = exec_command(module,
                                              create_pool(name,
-                                                         user_pool_config=user_pool_config))  # noqa: E501
+                                                         user_pool_config=user_pool_config), image=image, fsid=fsid, hostname=hostname)  # noqa: E501
             if user_pool_config['application']['value']:
                 rc, _, _, _ = exec_command(module,
                                            enable_application_pool(name,
-                                                                   user_pool_config['application']['value']))  # noqa: E501
+                                                                   user_pool_config['application']['value']), image=image, fsid=fsid, hostname=hostname)  # noqa: E501
             if user_pool_config['min_size']['value']:
                 # not implemented yet
                 pass
             if user_pool_config['allow_ec_overwrites']['value']:
                 rc, _, _, _ = exec_command(module,
-                                           enable_ec_overwrites(name))
+                                           enable_ec_overwrites(name, image=image, fsid=fsid, hostname=hostname))
 
             changed = True
 
     elif state == "list":
         rc, cmd, out, err = exec_command(module,
                                          list_pools(name,
-                                                    details))
+                                                    details, image, fsid, hostname))
         if rc != 0:
             out = "Couldn't list pool(s) present on the cluster"
 
     elif state == "absent":
         rc, cmd, out, err = exec_command(module,
-                                         check_pool_exist(name))
+                                         check_pool_exist(name, image=image, fsid=fsid, hostname=hostname))
         if rc == 0:
             rc, cmd, out, err = exec_command(module,
-                                             remove_pool(name))
+                                             remove_pool(name, image=image, fsid=fsid, hostname=hostname))
             changed = True
         else:
             rc = 0

--- a/roles/cephadm/tasks/bootstrap.yml
+++ b/roles/cephadm/tasks/bootstrap.yml
@@ -40,28 +40,40 @@
 
 - name: Set public network
   command:
-    cmd: "cephadm shell -- ceph config set mon public_network {{ cephadm_public_network }}"
+    cmd: >
+      cephadm shell {% if cephadm_fsid | length > 0 %} --fsid {{ cephadm_fsid }}
+      --config /var/lib/ceph/{{ cephadm_fsid }}/mon.{{ inventory_hostname }}/config
+      {% endif %} -- ceph config set mon public_network {{ cephadm_public_network }}
   become: true
   changed_when: true
   when: cephadm_public_network | length > 0
 
 - name: Set cluster network
   command:
-    cmd: "cephadm shell -- ceph config set global cluster_network {{ cephadm_cluster_network }}"
+    cmd: >
+      cephadm shell {% if cephadm_fsid | length > 0 %} --fsid {{ cephadm_fsid }}
+      --config /var/lib/ceph/{{ cephadm_fsid }}/mon.{{ inventory_hostname }}/config
+      {% endif %} -- ceph config set global cluster_network {{ cephadm_cluster_network }}
   when: cephadm_cluster_network | length > 0
   become: true
   changed_when: true
 
 - name: Set HAProxy image
   command:
-    cmd: "cephadm shell -- ceph config set mgr mgr/cephadm/container_image_haproxy {{ cephadm_haproxy_image }}"
+    cmd: >
+      cephadm shell {% if cephadm_fsid | length > 0 %} --fsid {{ cephadm_fsid }}
+      --config /var/lib/ceph/{{ cephadm_fsid }}/mon.{{ inventory_hostname }}/config
+      {% endif %} -- ceph config set mgr mgr/cephadm/container_image_haproxy {{ cephadm_haproxy_image }}
   when: cephadm_haproxy_image | length > 0
   become: true
   changed_when: true
 
 - name: Set Keepalived image
   command:
-    cmd: "cephadm shell -- ceph config set mgr mgr/cephadm/container_image_keepalived {{ cephadm_keepalived_image }}"
+    cmd: >
+      cephadm shell {% if cephadm_fsid | length > 0 %} --fsid {{ cephadm_fsid }}
+      --config /var/lib/ceph/{{ cephadm_fsid }}/mon.{{ inventory_hostname }}/config
+      {% endif %} -- ceph config set mgr mgr/cephadm/container_image_keepalived {{ cephadm_keepalived_image }}
   when: cephadm_keepalived_image | length > 0
   become: true
   changed_when: true
@@ -90,7 +102,14 @@
 - name: Apply spec
   command:
     cmd: >
-         cephadm shell --
+         cephadm {% if cephadm_image | length > 0 %}
+         --image {{ cephadm_image }} {% endif %}
+         shell
+         {% if cephadm_fsid | length > 0 %}
+         --fsid {{ cephadm_fsid }}
+         --config
+         /var/lib/ceph/{{ cephadm_fsid }}/mon.{{ inventory_hostname }}/config
+         {% endif %} --
          ceph orch apply -i /var/run/ceph/cephadm_cluster.yml
   changed_when: true
   become: true

--- a/roles/cephadm/tasks/destroy.yml
+++ b/roles/cephadm/tasks/destroy.yml
@@ -1,7 +1,14 @@
 ---
 - name: Get Ceph FSID
   command:
-    cmd: "cephadm shell -- ceph fsid"
+    cmd: "cephadm {% if cephadm_image | length > 0 %}
+         --image {{ cephadm_image }} {% endif %}
+         shell
+         {% if cephadm_fsid | length > 0 %}
+         --fsid {{ cephadm_fsid }}
+         --config
+         /var/lib/ceph/{{ cephadm_fsid }}/mon.{{ inventory_hostname }}/config
+         {% endif %} -- ceph fsid"
   become: true
   register: cephadm_destroy_fsid
   changed_when: false

--- a/roles/cephadm/tasks/osds.yml
+++ b/roles/cephadm/tasks/osds.yml
@@ -8,8 +8,15 @@
 - name: Add OSDs individually
   command:
     cmd: >
-         cephadm shell --
-         ceph orch daemon add osd {{ ansible_facts.nodename }}:{{ item }}
+         cephadm {% if cephadm_image | length > 0 %}
+         --image {{ cephadm_image }} {% endif %}
+         shell
+         {% if cephadm_fsid | length > 0 %}
+         --fsid {{ cephadm_fsid }}
+         --config
+         /var/lib/ceph/{{ cephadm_fsid }}/mon.{{ inventory_hostname }}/config
+         {% endif %}
+         -- ceph orch daemon add osd {{ ansible_facts.nodename }}:{{ item }}
   become: true
   register: osd_add_result
   changed_when: not osd_add_result.stdout.startswith("Created no osd(s) on host")

--- a/roles/cephadm/tasks/osds_spec.yml
+++ b/roles/cephadm/tasks/osds_spec.yml
@@ -1,7 +1,14 @@
 ---
 - name: Get cluster fsid
   command:
-    cmd: "cephadm shell -- ceph fsid"
+    cmd: "cephadm {% if cephadm_image | length > 0 %}
+         --image {{ cephadm_image }} {% endif %}
+         shell
+         {% if cephadm_fsid | length > 0 %}
+         --fsid {{ cephadm_fsid }}
+         --config
+         /var/lib/ceph/{{ cephadm_fsid }}/mon.{{ inventory_hostname }}/config
+         {% endif %} -- ceph fsid"
   when: cephadm_fsid | length == 0
   become: true
   register: cephadm_fsid_current
@@ -21,7 +28,14 @@
 - name: Apply OSDs spec
   command:
     cmd: >
-         cephadm shell --
-         ceph orch apply -i /var/run/ceph/osd_spec.yml
+         cephadm {% if cephadm_image | length > 0 %}
+         --image {{ cephadm_image }} {% endif %}
+         shell
+         {% if cephadm_fsid | length > 0 %}
+         --fsid {{ cephadm_fsid }}
+         --config
+         /var/lib/ceph/{{ cephadm_fsid }}/mon.{{ inventory_hostname }}/config
+         {% endif %}
+         -- ceph orch apply -i /var/run/ceph/osd_spec.yml
   become: true
   changed_when: true

--- a/roles/commands/defaults/main.yml
+++ b/roles/commands/defaults/main.yml
@@ -4,3 +4,5 @@ cephadm_commands: []
 cephadm_commands_until: true
 cephadm_commands_retries: 0
 cephadm_commands_delay: 0
+cephadm_fsid: ""
+cephadm_image: ""

--- a/roles/commands/tasks/main.yml
+++ b/roles/commands/tasks/main.yml
@@ -1,7 +1,15 @@
 ---
 - name: Execute custom commands
   command:
-    cmd: "cephadm shell -- {{ cephadm_command }} {{ item }}"
+    cmd: "cephadm {% if cephadm_image | length > 0 %}
+         --image {{ cephadm_image }} {% endif %}
+         shell
+         {% if cephadm_fsid | length > 0 %}
+         --fsid {{ cephadm_fsid }}
+         --config
+         /var/lib/ceph/{{ cephadm_fsid }}/mon.{{ inventory_hostname }}/config
+         {% endif %}
+         -- {{ cephadm_command }} {{ item }}"
   register: cephadm_commands_result
   with_items: "{{ cephadm_commands }}"
   become: true

--- a/roles/crush_rules/tasks/main.yml
+++ b/roles/crush_rules/tasks/main.yml
@@ -8,6 +8,9 @@
     bucket_type: "{{ item.bucket_type | default(omit) }}"
     device_class: "{{ item.device_class | default(omit) }}"
     profile: "{{ item.profile | default(omit) }}"
+    image: "{{ cephadm_image }}"
+    fsid: "{{ cephadm_fsid | default(omit) }}"
+    hostname: "{{ inventory_hostname }}"
   with_items: "{{ cephadm_crush_rules }}"
   delegate_to: "{{ groups['mons'][0] }}"
   run_once: true

--- a/roles/ec_profiles/tasks/main.yml
+++ b/roles/ec_profiles/tasks/main.yml
@@ -11,6 +11,9 @@
     crush_root: "{{ item.crush_root | default(omit) }}"
     crush_device_class: "{{ item.crush_device_class | default(omit) }}"
     crush_failure_domain: "{{ item.crush_failure_domain | default(omit) }}"
+    image: "{{ cephadm_image }}"
+    fsid: "{{ cephadm_fsid | default(omit) }}"
+    hostname: "{{ inventory_hostname }}"
   with_items: "{{ cephadm_ec_profiles }}"
   delegate_to: "{{ groups['mons'][0] }}"
   run_once: true

--- a/roles/keys/tasks/main.yml
+++ b/roles/keys/tasks/main.yml
@@ -5,6 +5,9 @@
     state: "{{ item.state | default(omit) }}"
     caps: "{{ item.caps }}"
     secret: "{{ item.key | default(omit) }}"
+    image: "{{ cephadm_image }}"
+    fsid: "{{ cephadm_fsid | default(omit) }}"
+    hostname: "{{ inventory_hostname }}"
   with_items: "{{ cephadm_keys }}"
   delegate_to: "{{ groups['mons'][0] }}"
   run_once: true

--- a/roles/pools/tasks/main.yml
+++ b/roles/pools/tasks/main.yml
@@ -14,6 +14,9 @@
     target_size_ratio: "{{ item.target_size_ratio | default(omit) }}"
     application: "{{ item.application | default(omit) }}"
     allow_ec_overwrites: "{{ item.allow_ec_overwrites | default(omit) }}"
+    image: "{{ cephadm_image }}"
+    fsid: "{{ cephadm_fsid | default(omit) }}"
+    hostname: "{{ inventory_hostname }}"
   with_items: "{{ cephadm_pools }}"
   delegate_to: "{{ groups['mons'][0] }}"
   run_once: true


### PR DESCRIPTION
It has been noticed that if you add `--fsid` and `--config` it can speed up the time to execute commands as it avoids having to look up this information.

Before

```
Wednesday 11 March 2026  08:50:17 +0000 (0:04:49.900)       0:04:49.979 *******
===============================================================================
stackhpc.cephadm.commands : Execute custom commands ------------------------------------------------------------------- 289.90s
```

After

```
Wednesday 11 March 2026  09:13:41 +0000 (0:01:52.667)       0:01:52.742 *******
===============================================================================
stackhpc.cephadm.commands : Execute custom commands ------------------------------------------------------------------- 112.67s
```