### PR TITLE
feat: add `mds` group support

### DIFF
--- a/roles/cephadm/README.md
+++ b/roles/cephadm/README.md
@@ -23,6 +23,7 @@ This role assumes the existence of the following groups:
 Optional groups (those services will be deployed when group exists)::
 
 * `rgws`
+* `mds`
 
 All Ceph hosts must be in the `ceph` group.
 

--- a/roles/cephadm/templates/cluster.yml.j2
+++ b/roles/cephadm/templates/cluster.yml.j2
@@ -21,6 +21,9 @@ labels:
 {% if host in groups.get('ingress', []) %}
   - ingress
 {% endif %}
+{% if host in groups.get('mds', []) %}
+  - mds
+{% endif %}
 {% if hostvars[host].get('cephadm_host_labels', []) | length > 0 %}
 {% for label in hostvars[host].cephadm_host_labels %}
   - {{ label }}


### PR DESCRIPTION
If hosts belong to the `mds` group then attach a label for `mds`. This label can then be used to schedule `mds` to specific hosts.