### PR TITLE
Update actions to org-wide pins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
           ansible-test coverage report
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
+        uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe # v4.3.1
         if: success() || failure() # always run even if the previous step fails
         with:
           report_paths: '**/tests/output/*/*.xml'


### PR DESCRIPTION
This replaces https://github.com/stackhpc/ansible-collection-cephadm/pull/200 and instead uses org-wide pins from https://github.com/stackhpc/github-actions-list/blob/main/stackhpc.pinned.txt