### PR TITLE
feat: add support for `extra_container_args`

### DIFF
--- a/roles/cephadm/README.md
+++ b/roles/cephadm/README.md
@@ -36,6 +36,7 @@ All Ceph hosts must be in the `ceph` group.
   * `cephadm_custom_repos`: Boolean: disables configuring offical Ceph YUM/APT repositories - `cephadm_ceph_release` is ignored. Can serve as a workaround for a lack of supported OS distro + Ceph release combination upstream. (default: false)
   * `cephadm_package_update`: If enabled - cephadm package will be updated to latest version (default: false)
   * `cephadm_host_labels`: If set (list format) - those additional labels will be applied to host definitions (default: [] - empty list)
+  * `cephadm_extra_container_args`: If set (list format) - these additional arguments will be applied to all containers managed by cephadm (default: [] - empty list)
   * Bootstrap settings
     * `cephadm_bootstrap_host`: The host on which to bootstrap Ceph (default: `groups['mons'][0]`)
     * `cephadm_enable_dashboard`: If enabled - dashboard service on MGR will be enabled (default: false)

--- a/roles/cephadm/defaults/main.yml
+++ b/roles/cephadm/defaults/main.yml
@@ -50,3 +50,5 @@ cephadm_radosgw_services: []
 cephadm_ingress_services: []
 # Container Engine
 cephadm_container_engine: "docker"
+# Additional container arguments
+cephadm_extra_container_args: []

--- a/roles/cephadm/templates/cluster.yml.j2
+++ b/roles/cephadm/templates/cluster.yml.j2
@@ -32,17 +32,35 @@ service_type: mon
 placement:
   count: {{ cephadm_mon_count }}
   label: mon
+{% if cephadm_extra_container_args | length > 0 %}
+extra_container_args:
+{% for argument in cephadm_extra_container_args %}
+  - "{{ argument | quote }}"
+{% endfor %}
+{% endif %}
 ---
 service_type: mgr
 placement:
   count: {{ cephadm_mgr_count }}
   label: mgr
+{% if cephadm_extra_container_args | length > 0 %}
+extra_container_args:
+{% for argument in cephadm_extra_container_args %}
+  - "{{ argument | quote }}"
+{% endfor %}
+{% endif %}
 ---
 service_type: crash
 placement:
   host_pattern: "*"
 {% if groups.get('rgws', []) | length > 0 %}
 {% for service in cephadm_radosgw_services %}
+{% if cephadm_extra_container_args | length > 0 %}
+extra_container_args:
+{% for argument in cephadm_extra_container_args %}
+  - "{{ argument | quote }}"
+{% endfor %}
+{% endif %}
 ---
 service_type: rgw
 service_id: {{ service.id }}
@@ -67,11 +85,23 @@ networks:
 {% endif %}
 {% if groups.get('ingress', []) | length > 0 %}
 {% for service in cephadm_ingress_services %}
+{% if cephadm_extra_container_args | length > 0 %}
+extra_container_args:
+{% for argument in cephadm_extra_container_args %}
+  - "{{ argument | quote }}"
+{% endfor %}
+{% endif %}
 ---
 service_type: ingress
 service_id: {{ service.id }}
 placement:
   label: ingress
 {{ {"spec": service.spec} | to_nice_yaml(indent=2) }}
+{% endfor %}
+{% endif %}
+{% if cephadm_extra_container_args | length > 0 %}
+extra_container_args:
+{% for argument in cephadm_extra_container_args %}
+  - "{{ argument | quote }}"
 {% endfor %}
 {% endif %}

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -141,3 +141,25 @@
     vars:
       cephadm_ceph_release: tentacle
       cephadm_container_engine: podman
+
+# Container args
+
+- job:
+    name: cephadm-rocky9-multinode-docker-squid-container-args
+    parent: .cephadm-rocky9-multinode-template
+    vars:
+      cephadm_ceph_release: squid
+      cephadm_container_engine: docker
+      cephadm_extra_container_args:
+        - "-v"
+        - "/etc/pki/tls/certs/ca-bundle.crt:/etc/pki/tls/certs/ca-bundle.crt:ro"
+
+- job:
+    name: cephadm-rocky9-multinode-podman-squid-container-args
+    parent: .cephadm-rocky9-multinode-template
+    vars:
+      cephadm_ceph_release: squid
+      cephadm_container_engine: podman
+      cephadm_extra_container_args:
+        - "-v"
+        - "/etc/pki/tls/certs/ca-bundle.crt:/etc/pki/tls/certs/ca-bundle.crt:ro"

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -12,6 +12,8 @@
         - cephadm-rocky9-multinode-podman-reef
         - cephadm-rocky9-multinode-docker-squid
         - cephadm-rocky9-multinode-podman-squid
+        - cephadm-rocky9-multinode-docker-squid-container-args
+        - cephadm-rocky9-multinode-podman-squid-container-args
         - tox-linters
     gate:
       jobs:
@@ -23,3 +25,5 @@
         - cephadm-rocky9-multinode-podman-reef
         - cephadm-rocky9-multinode-docker-squid
         - cephadm-rocky9-multinode-podman-squid
+        - cephadm-rocky9-multinode-docker-squid-container-args
+        - cephadm-rocky9-multinode-podman-squid-container-args


### PR DESCRIPTION
Support the addition of custom container arguments that are applied to all daemons managed by `cephadm`.